### PR TITLE
Remove uuid dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ performance, or other attributes of fencedframes, since it won't use them at
 all.
 
 The `auctionWinnerUrl` will be the same URL as the FLEDGE Shim frame, with a
-randomly generated UUID appended in the fragment. When rendered with such a
+randomly generated token appended in the fragment. When rendered with such a
 token in its URL fragment, the FLEDGE Shim frame will create a nested iframe
 inside itself pointing at the original `rendering_url`. This only works from the
 same page that called `runAdAuction`.

--- a/frame/auction.ts
+++ b/frame/auction.ts
@@ -6,7 +6,6 @@
 
 /** @fileoverview Selection of ads, and creation of tokens to display them. */
 
-import * as uuid from "uuid";
 import { getAllAds } from "./database";
 
 /**
@@ -28,7 +27,15 @@ export async function runAdAuction(): Promise<string | null> {
       winningPrice = price;
     }
   }
-  const token = uuid.v4();
+  const token = randomToken();
   sessionStorage.setItem(token, winningRenderingUrl);
   return token;
+}
+
+function randomToken() {
+  return Array.prototype.map
+    .call(crypto.getRandomValues(new Uint8Array(16)), (byte: number) =>
+      byte.toString(/* radix= */ 16).padStart(2, "0")
+    )
+    .join("");
 }

--- a/frame/auction_test.ts
+++ b/frame/auction_test.ts
@@ -36,4 +36,11 @@ describe("runAdAuction", () => {
     expect(token).toBeNull();
     expect(sessionStorage.length).toBe(0);
   });
+
+  it("should return tokens in the expected format", async () => {
+    await setInterestGroupAds("interest group name", [["about:blank", 0.02]]);
+    for (let i = 0; i < 100; i++) {
+      expect(await runAdAuction()).toMatch(/^[0-9a-f]{32}$/);
+    }
+  });
 });

--- a/frame/main_test.ts
+++ b/frame/main_test.ts
@@ -5,7 +5,6 @@
  */
 
 import "jasmine";
-import * as uuid from "uuid";
 import {
   awaitMessageFromSelfToSelf,
   awaitMessageToPort,
@@ -53,8 +52,9 @@ describe("main", () => {
     );
   });
 
+  const token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
   it("should render an ad", () => {
-    const token = uuid.v4();
     sessionStorage.setItem(token, renderingUrl);
     const iframe = document.createElement("iframe");
     iframe.src = "about:blank#" + token;
@@ -67,7 +67,6 @@ describe("main", () => {
   });
 
   it("should throw on invalid token", () => {
-    const token = uuid.v4();
     const iframe = document.createElement("iframe");
     iframe.src = "about:blank#" + token;
     document.body.appendChild(iframe);

--- a/lib/testing/public_api_test.ts
+++ b/lib/testing/public_api_test.ts
@@ -5,7 +5,6 @@
  */
 
 import "jasmine";
-import * as uuid from "uuid";
 import { clearStorageBeforeAndAfter } from "../../lib/shared/testing/storage";
 import { assert } from "../../lib/shared/testing/types";
 import { FledgeShim } from "../public_api";
@@ -33,9 +32,10 @@ describe("create", () => {
 describe("renderingUrlFromAuctionResult", () => {
   clearStorageBeforeAndAfter();
 
+  const token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const renderingUrl = "about:blank#ad";
+
   it("should return the rendering URL from an auction result", async () => {
-    const token = uuid.v4();
-    const renderingUrl = "about:blank#ad";
     sessionStorage.setItem(token, renderingUrl);
     expect(await renderingUrlFromAuctionResult("/frame.html#" + token)).toBe(
       renderingUrl
@@ -43,8 +43,6 @@ describe("renderingUrlFromAuctionResult", () => {
   });
 
   it("should clean up after itself", async () => {
-    const token = uuid.v4();
-    const renderingUrl = "about:blank#ad";
     sessionStorage.setItem(token, renderingUrl);
     const existingDom = document.documentElement.cloneNode(/* deep= */ true);
     assert(existingDom instanceof HTMLHtmlElement);

--- a/package-lock.json
+++ b/package-lock.json
@@ -568,12 +568,6 @@
         "@types/node": "*"
       }
     },
-    "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
-      "dev": true
-    },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.20.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.20.0.tgz",
@@ -8822,11 +8816,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,13 @@
   },
   "dependencies": {
     "idb-keyval": "^5.0.4",
-    "tslib": "^2.1.0",
-    "uuid": "^8.3.2"
+    "tslib": "^2.1.0"
   },
   "devDependencies": {
     "@angular/compiler": "^11.2.7",
     "@angular/compiler-cli": "^11.2.7",
     "@angular/core": "^11.2.7",
     "@types/jasmine": "^3.6.9",
-    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
     "eslint": "^7.23.0",


### PR DESCRIPTION
This removes an obstacle to using the library in conjunction with Closure Compiler.

The tokens are technically no longer UUIDs, but we don't actually care about that, we just want a string with enough random bits.