### PR TITLE
Tweak definition of isKeyValueObject to handle other types

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -23,13 +23,14 @@ export function isObject(
 }
 
 /**
- * Returns whether the given value is a non-array object. This is intended for
+ * Returns whether the given value is a plain-old-data object (i.e., not an
+ * array or function or instance of some other type). This is intended for
  * runtime type checking of values parsed from JSON.
  */
 export function isKeyValueObject(
   value: unknown
 ): value is { readonly [key: string]: unknown } {
-  return typeof value === "object" && value !== null && !isArray(value);
+  return isObject(value) && Object.getPrototypeOf(value) === Object.prototype;
 }
 
 /**

--- a/lib/shared/types_test.ts
+++ b/lib/shared/types_test.ts
@@ -22,6 +22,12 @@ describe("isObject", () => {
   it("should return true for []", () => {
     expect(isObject([])).toBeTrue();
   });
+  it("should return true for function", () => {
+    expect(isObject(() => null)).toBeTrue();
+  });
+  it("should return true for Date", () => {
+    expect(isObject(new Date())).toBeTrue();
+  });
   it("should return false for null", () => {
     expect(isObject(null)).toBeFalse();
   });
@@ -36,6 +42,12 @@ describe("isKeyValueObject", () => {
   });
   it("should return false for []", () => {
     expect(isKeyValueObject([])).toBeFalse();
+  });
+  it("should return false for function", () => {
+    expect(isKeyValueObject(() => null)).toBeFalse();
+  });
+  it("should return false for Date", () => {
+    expect(isKeyValueObject(new Date())).toBeFalse();
   });
   it("should return false for null", () => {
     expect(isKeyValueObject(null)).toBeFalse();


### PR DESCRIPTION
This isn't needed for JSON but may be needed for other stuff later and is slightly more correct regardless.