### PR TITLE
Clean up order-dependent tests

### DIFF
--- a/lib/shared/testing/dom_test.ts
+++ b/lib/shared/testing/dom_test.ts
@@ -12,47 +12,48 @@ const ID = "clean-dom-after-each-child";
 describe("cleanDomAfterEach", () => {
   describe("with child in head", () => {
     cleanDomAfterEach();
-    it("adds it to the DOM head", () => {
-      const child = document.createElement("style");
-      child.id = ID;
-      document.head.appendChild(child);
-      expect(document.getElementById(ID)).toBe(child);
-      expect(child.parentNode).toBe(document.head);
-    });
-    it("should have cleared it away after the preceding test case", () => {
-      expect(document.getElementById(ID)).toBeNull();
-    });
+    for (const nth of ["first", "second"]) {
+      it(`should not already be present when adding it (${nth} time)`, () => {
+        expect(document.getElementById(ID)).toBeNull();
+        const child = document.createElement("style");
+        child.id = ID;
+        document.head.appendChild(child);
+        expect(document.getElementById(ID)).toBe(child);
+        expect(child.parentNode).toBe(document.head);
+      });
+    }
   });
 
   describe("with child in body", () => {
     cleanDomAfterEach();
-    it("adds it to the DOM body", () => {
-      const child = document.createElement("div");
-      child.id = ID;
-      document.body.appendChild(child);
-      expect(document.getElementById(ID)).toBe(child);
-      expect(child.parentNode).toBe(document.body);
-    });
-    it("should have cleared it away after the preceding test case", () => {
-      expect(document.getElementById(ID)).toBeNull();
-    });
+    for (const nth of ["first", "second"]) {
+      it(`should not already be present when adding it (${nth} time)`, () => {
+        expect(document.getElementById(ID)).toBeNull();
+        const child = document.createElement("div");
+        child.id = ID;
+        document.body.appendChild(child);
+        expect(document.getElementById(ID)).toBe(child);
+        expect(child.parentNode).toBe(document.body);
+      });
+    }
   });
 
-  describe("with attribute", () => {
+  describe("with attribute on DOM root", () => {
     cleanDomAfterEach();
-    it("adds it to the DOM root", () => {
-      document.documentElement.dataset["cleanDomAfterEachAttribute"] = "value";
-      expect().nothing();
-    });
-    it("should have cleared it away after the preceding test case", () => {
-      expect("cleanDomAfterEachAttribute" in document.documentElement.dataset)
-        .withContext(
-          `Element should not have data-clean-dom-after-each-attribute=${
-            document.documentElement.dataset["cleanDomAfterEachAttribute"] ?? ""
-          }`
-        )
-        .toBeFalse();
-    });
+    for (const nth of ["first", "second"]) {
+      it(`should not already be present when adding it (${nth} time)`, () => {
+        expect("cleanDomAfterEachAttribute" in document.documentElement.dataset)
+          .withContext(
+            `Element should not have data-clean-dom-after-each-attribute=${
+              document.documentElement.dataset["cleanDomAfterEachAttribute"] ??
+              ""
+            }`
+          )
+          .toBeFalse();
+        document.documentElement.dataset["cleanDomAfterEachAttribute"] =
+          "value";
+      });
+    }
   });
 
   describe("with beforeEach", () => {

--- a/lib/shared/testing/storage_test.ts
+++ b/lib/shared/testing/storage_test.ts
@@ -11,29 +11,29 @@ import { clearStorageBeforeAndAfter } from "./storage";
 describe("clearStorageBeforeAndAfter", () => {
   describe("with sessionStorage", () => {
     clearStorageBeforeAndAfter();
-    it("stores an item", () => {
-      const key = "sessionStorage key";
-      const value = "sessionStorage value";
-      sessionStorage.setItem(key, value);
-      expect(sessionStorage.getItem(key)).toBe(value);
-    });
-    it("should have cleared it after the preceding test case", () => {
-      expect(sessionStorage.length).toBe(0);
-    });
+    for (const nth of ["first", "second"]) {
+      it(`should not already contain item when adding it (${nth} time)`, () => {
+        expect(sessionStorage.length).toBe(0);
+        const key = "sessionStorage key";
+        const value = "sessionStorage value";
+        sessionStorage.setItem(key, value);
+        expect(sessionStorage.getItem(key)).toBe(value);
+      });
+    }
   });
 
   describe("with idb-keyval", () => {
     clearStorageBeforeAndAfter();
-    it("stores an item", async () => {
-      const key = "idb-keyval key";
-      const value = "idb-keyval value";
-      await idbKeyval.set(key, value);
-      const retrieved: unknown = await idbKeyval.get(key);
-      expect(retrieved).toBe(value);
-    });
-    it("should have cleared it after the preceding test case", async () => {
-      expect(await idbKeyval.entries()).toEqual([]);
-    });
+    for (const nth of ["first", "second"]) {
+      it(`should not already contain item when adding it (${nth} time)`, async () => {
+        expect(await idbKeyval.entries()).toEqual([]);
+        const key = "idb-keyval key";
+        const value = "idb-keyval value";
+        await idbKeyval.set(key, value);
+        const retrieved: unknown = await idbKeyval.get(key);
+        expect(retrieved).toBe(value);
+      });
+    }
   });
 
   describe("with beforeEach", () => {

--- a/lib/testing/public_api_test.ts
+++ b/lib/testing/public_api_test.ts
@@ -12,16 +12,13 @@ import { create, renderingUrlFromAuctionResult } from "./public_api";
 
 describe("create", () => {
   let fledgeShim: FledgeShim;
-  function createOrExpectDestroyed() {
-    if (fledgeShim) {
-      expect(fledgeShim.isDestroyed()).toBeTrue();
-    } else {
-      fledgeShim = create();
-      expect(fledgeShim).toBeInstanceOf(FledgeShim);
-    }
-  }
-  it("should create on the first run", createOrExpectDestroyed);
-  it("should be destroyed on the second run", createOrExpectDestroyed);
+  it("should return a FledgeShim", () => {
+    fledgeShim = create();
+    expect(fledgeShim).toBeInstanceOf(FledgeShim);
+  });
+  afterAll(() => {
+    expect(fledgeShim.isDestroyed()).toBeTrue();
+  });
 
   it("should not try to re-destroy an already destroyed FledgeShim", () => {
     create().destroy();


### PR DESCRIPTION
Jasmine in the default configuration randomizes test order, which is generally good, but creates some awkwardness for unit tests of testing utilities that assert that those utilities clean up after themselves and don't allow state leakage. I'm changing some tests along those lines to use a new pattern that explicitly runs the same test spec multiple times and asserts that it behaves the same way every time.