### PR TITLE
Create service-worker-based library for hermetic testing of HTTP requests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
   ignorePatterns: [
     "dist/",
     ".eslintrc.js",
+    "fake_server.js",
     "karma.conf.js",
     "webpack.config.js",
   ],

--- a/fake_server.js
+++ b/fake_server.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @fileoverview Service Worker installed by `./lib/shared/testing/http`. */
+
+onactivate = (event) => {
+  // The service worker is installed by the Karma test window at the beginning
+  // of the tests. We want it to take control of that window so that it can
+  // intercept subsequent fetches made in the tests.
+  event.waitUntil(clients.claim());
+};
+
+let port;
+
+onmessage = (messageEvent) => {
+  [port] = messageEvent.ports;
+  // If the browser puts the service worker to sleep, then on the next fetch
+  // this whole script will be reevaluated and the value assigned to port will
+  // no longer be present. We can't let that happen; we need a consistent port
+  // throughout the tests. So we leave an event pending until the test sends a
+  // message to explicitly indicate that it's done running; this ensures that
+  // the browser will keep the service worker awake.
+  messageEvent.waitUntil(
+    new Promise((resolve) => {
+      port.onmessage = resolve;
+    })
+  );
+  // Tell the test code that the port has been set and so we're now ready to
+  // receive and handle fetches.
+  port.postMessage(null);
+};
+
+onfetch = (fetchEvent) => {
+  if (!new URL(fetchEvent.request.url).hostname.endsWith(".test")) {
+    return;
+  }
+  const { port1: receiver, port2: sender } = new MessageChannel();
+  fetchEvent.respondWith(
+    new Promise((resolve) => {
+      receiver.onmessage = ({ data }) => {
+        receiver.close();
+        resolve(new Response(data));
+      };
+    })
+  );
+  port.postMessage(fetchEvent.request.url, [sender]);
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,9 +25,14 @@ module.exports = (config) => {
       },
     ],
     frameworks: ["jasmine", "karma-typescript"],
-    files: ["frame/**/*.ts", "lib/**/*.ts"],
+    files: [
+      "frame/**/*.ts",
+      "lib/**/*.ts",
+      { pattern: "fake_server.js", included: false },
+    ],
     middleware: ["webpack-dev"],
     preprocessors: { "**/*.ts": "karma-typescript" },
+    proxies: { "/fake_server.js": "/base/fake_server.js" },
     reporters: ["progress", "karma-typescript"],
     browsers: ["ChromeHeadless"],
     karmaTypescriptConfig: {

--- a/lib/shared/testing/http.ts
+++ b/lib/shared/testing/http.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Utility functions used only in test code, that facilitate
+ * hermetic testing of HTTP requests.
+ *
+ * Any request to a `.test` domain will be intercepted by a service worker. This
+ * code installs the service worker and manages its lifecycle, and allows test
+ * code to control responses to such requests. Such responses always have status
+ * 200 and no additional headers. By default, they have an empty body.
+ *
+ * We use a service worker instead of simply monkeypatching `fetch` because
+ * end-to-end tests of the library require intercepting requests made from
+ * within the frame, and test code for those tests doesn't run within the frame,
+ * so there's no opportunity to monkeypatch.
+ */
+
+import "jasmine";
+import { awaitMessageToPort } from "../messaging";
+import { assert, nonNullish } from "../types";
+
+/** A callback that consumes an HTTP request and returns a response. */
+export type FakeServerHandler = (requestUrl: URL) => Promise<string>;
+
+let registration: ServiceWorkerRegistration;
+let port: MessagePort;
+let currentHandler: FakeServerHandler;
+
+/**
+ * For the remainder of the current test spec, whenever an HTTP request is made
+ * to a `.test` URL, call the given handler function passing that URL, and use
+ * its return value as the response body, instead of the default empty string.
+ * If this has already been called earlier in the same spec, the previous
+ * handler is overwritten.
+ *
+ * Don't call this if an HTTP request has been sent but its response hasn't been
+ * awaited; race conditions are likely to occur in that case.
+ */
+export function setFakeServerHandler(handler: FakeServerHandler): void {
+  currentHandler = handler;
+}
+
+function resetHandler() {
+  setFakeServerHandler(() => Promise.resolve(""));
+}
+resetHandler();
+afterEach(resetHandler);
+
+beforeAll(async () => {
+  const controllerChangePromise = new Promise((resolve) => {
+    navigator.serviceWorker.addEventListener("controllerchange", resolve, {
+      once: true,
+    });
+  });
+  registration = await navigator.serviceWorker.register("/fake_server.js");
+  await controllerChangePromise;
+  const channel = new MessageChannel();
+  port = channel.port1;
+  const readyMessagePromise = awaitMessageToPort(port);
+  nonNullish(navigator.serviceWorker.controller).postMessage(null, [
+    channel.port2,
+  ]);
+  await readyMessagePromise;
+  port.onmessage = async ({ data, ports }: MessageEvent<unknown>) => {
+    assert(typeof data === "string");
+    ports[0].postMessage(await currentHandler(new URL(data)));
+  };
+});
+
+afterAll(() => {
+  port.postMessage(null);
+  port.close();
+  return registration.unregister();
+});

--- a/lib/shared/testing/http_test.ts
+++ b/lib/shared/testing/http_test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "jasmine";
+import { FakeServerHandler, setFakeServerHandler } from "./http";
+
+describe("setFakeServerHandler", () => {
+  const url = "https://domain.test/path?key=value";
+  const responseBody = "response body string";
+
+  it("should respond to a fetch request with a custom handler", async () => {
+    const fakeServerHandler = jasmine
+      .createSpy<FakeServerHandler>()
+      .and.resolveTo(responseBody);
+    setFakeServerHandler(fakeServerHandler);
+    const response = await fetch(url);
+    expect(await response.text()).toBe(responseBody);
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(new URL(url));
+  });
+
+  for (const nth of ["first", "second"]) {
+    it(`should respond with an empty body before handler is set (${nth} time)`, async () => {
+      expect(await (await fetch(url)).text()).toEqual("");
+      setFakeServerHandler(() => Promise.resolve(responseBody));
+      expect(await (await fetch(url)).text()).toEqual(responseBody);
+    });
+  }
+
+  describe("with beforeEach", () => {
+    beforeEach(() => {
+      setFakeServerHandler(() => Promise.resolve(responseBody));
+    });
+    it("should have set a handler", async () => {
+      expect(await (await fetch(url)).text()).toEqual(responseBody);
+    });
+  });
+});


### PR DESCRIPTION
This is needed in order to test the parts of FLEDGE that call out to servers.