### PR TITLE
Add Jasmine matcher utilities for URLs

### DIFF
--- a/lib/shared/testing/url.ts
+++ b/lib/shared/testing/url.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Utility functions used only in test code, that facilitate
+ * assertions on URLs.
+ */
+
+import "jasmine";
+
+/**
+ * Returns a Jasmine matcher that matches a `URLSearchParams` object whose
+ * `entries` match the given value.
+ */
+export function queryParamsMatching(
+  expected: jasmine.ExpectedRecursive<jasmine.ArrayLike<[string, string]>>
+): jasmine.AsymmetricMatcher<URLSearchParams> {
+  return {
+    asymmetricMatch: (searchParams) =>
+      jasmine.matchersUtil.equals(expected, [...searchParams.entries()]),
+  };
+}
+
+/**
+ * Returns a Jasmine matcher that matches the strings in the given value,
+ * individually encoded with `encodeURIComponent` and then joined with `,`. This
+ * format is used to send multiple values in a single query parameter.
+ */
+export function joinedEncodedStringsMatching(
+  expected: jasmine.ExpectedRecursive<jasmine.ArrayLike<string>>
+): jasmine.AsymmetricMatcher<string> {
+  return {
+    asymmetricMatch: (encodedParamValue) =>
+      jasmine.matchersUtil.equals(
+        expected,
+        encodedParamValue.split(",").map(decodeURIComponent)
+      ),
+  };
+}

--- a/lib/shared/testing/url_test.ts
+++ b/lib/shared/testing/url_test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "jasmine";
+import { joinedEncodedStringsMatching, queryParamsMatching } from "./url";
+
+describe("queryParamsMatching", () => {
+  const queryParams = new URLSearchParams();
+  queryParams.append("key1", "value1");
+  queryParams.append("key2", "value2");
+
+  it("should match an array of entries of strings", () => {
+    expect(queryParams).toEqual(
+      queryParamsMatching([
+        ["key1", "value1"],
+        ["key2", "value2"],
+      ])
+    );
+  });
+
+  it("should match an array of entries of asymmetric matchers", () => {
+    expect(queryParams).toEqual(
+      queryParamsMatching([
+        [jasmine.stringMatching(/^key1$/), jasmine.stringMatching(/^value1$/)],
+        [jasmine.stringMatching(/^key2$/), jasmine.stringMatching(/^value2$/)],
+      ])
+    );
+  });
+
+  it("should match an asymmetric matcher", () => {
+    expect(queryParams).toEqual(
+      queryParamsMatching(
+        jasmine.arrayWithExactContents([
+          ["key1", "value1"],
+          ["key2", "value2"],
+        ])
+      )
+    );
+  });
+
+  it("should not match with an extra entry", () => {
+    expect(queryParams).not.toEqual(
+      queryParamsMatching([
+        ["key1", "value1"],
+        ["key2", "value2"],
+        ["key3", "value3"],
+      ])
+    );
+  });
+});
+
+describe("joinedEncodedStringsMatching", () => {
+  const joinedEncoded = "First!,Second.,Third%3F";
+
+  it("should match an array of strings", () => {
+    expect(joinedEncoded).toEqual(
+      joinedEncodedStringsMatching(["First!", "Second.", "Third?"])
+    );
+  });
+
+  it("should match an array of asymmetric matchers", () => {
+    expect(joinedEncoded).toEqual(
+      joinedEncodedStringsMatching([
+        jasmine.stringMatching(/^First!$/),
+        jasmine.stringMatching(/^Second\.$/),
+        jasmine.stringMatching(/^Third\?$/),
+      ])
+    );
+  });
+
+  it("should match an asymmetric matcher", () => {
+    expect(joinedEncoded).toEqual(
+      joinedEncodedStringsMatching(
+        jasmine.arrayWithExactContents(["First!", "Second.", "Third?"])
+      )
+    );
+  });
+
+  it("should not match with an extra string", () => {
+    expect(joinedEncoded).not.toEqual(
+      joinedEncodedStringsMatching(["First!", "Second.", "Third?", "Fourth"])
+    );
+  });
+});


### PR DESCRIPTION
These are needed in order to assert that network callouts use the right query parameters.