### PR TITLE
Add more features to fake server

### DIFF
--- a/frame/fetch_test.ts
+++ b/frame/fetch_test.ts
@@ -6,6 +6,7 @@
 
 import "jasmine";
 import {
+  DEFAULT_REQUEST_HEADERS,
   FakeServerHandler,
   setFakeServerHandler,
 } from "../lib/shared/testing/http";
@@ -13,24 +14,31 @@ import { FetchJsonStatus, tryFetchJson } from "./fetch";
 
 describe("tryFetchJson", () => {
   const url = "https://json-endpoint.test/path";
+  const expectedRequest = {
+    url: new URL(url),
+    method: "GET",
+    headers: DEFAULT_REQUEST_HEADERS,
+    body: Uint8Array.of(),
+    hasCredentials: false,
+  };
 
   it("should fetch a JSON value", async () => {
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
-      .and.resolveTo('{"a": 1, "b": [true, null]}');
+      .and.resolveTo({ body: '{"a": 1, "b": [true, null]}' });
     setFakeServerHandler(fakeServerHandler);
     const result = await tryFetchJson(url);
     expect(result).toEqual({
       status: FetchJsonStatus.OK,
       value: { "a": 1, "b": [true, null] },
     });
-    expect(fakeServerHandler).toHaveBeenCalledOnceWith(new URL(url));
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(expectedRequest);
   });
 
   it("should handle ill-formed JSON", async () => {
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
-      .and.resolveTo('{"a": 1?}');
+      .and.resolveTo({ body: '{"a": 1?}' });
     setFakeServerHandler(fakeServerHandler);
     const result = await tryFetchJson(url);
     expect(result).toEqual({
@@ -38,7 +46,7 @@ describe("tryFetchJson", () => {
       // Illegal character is at position 7 in the string
       errorMessage: jasmine.stringMatching(/.*\b7\b.*/),
     });
-    expect(fakeServerHandler).toHaveBeenCalledOnceWith(new URL(url));
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(expectedRequest);
   });
 
   it("should handle a network error", async () => {

--- a/lib/shared/testing/http.ts
+++ b/lib/shared/testing/http.ts
@@ -10,21 +10,91 @@
  *
  * Any request to a `.test` domain will be intercepted by a service worker. This
  * code installs the service worker and manages its lifecycle, and allows test
- * code to control responses to such requests. Such responses always have status
- * 200 and no additional headers. By default, they have an empty body.
+ * code to control responses to such requests. By default, an empty response is
+ * used.
  *
  * We use a service worker instead of simply monkeypatching `fetch` because
  * end-to-end tests of the library require intercepting requests made from
  * within the frame, and test code for those tests doesn't run within the frame,
- * so there's no opportunity to monkeypatch.
+ * so there's no opportunity to monkeypatch. We don't simulate everything
+ * perfectly (e.g., CORS), but the basics of HTTP requests and responses are
+ * covered.
  */
 
 import "jasmine";
 import { awaitMessageToPort } from "../messaging";
-import { assert, nonNullish } from "../types";
+import { assert, isArray, nonNullish } from "../types";
+
+/**
+ * The parts of an HTTP fetch request that this library simulates. This is
+ * passed to callers in the `FakeServerHandler` callback type, so for caller
+ * convenience, callers can assume they're all there and can mutate them.
+ */
+export interface FakeRequest {
+  /** Full absolute URL. */
+  url: URL;
+  /** GET, POST, etc. */
+  method: string;
+  /**
+   * Request headers, including ones that are provided by the browser like
+   * User-Agent, but excluding ones that the browser doesn't expose to
+   * JavaScript code like Cookie. Names are always lowercase. Duplicate headers
+   * aren't supported.
+   */
+  headers: { [name: string]: string };
+  /**
+   * Request body in binary format, after being read in its entirety.
+   * Incremental streaming of the body isn't supported.
+   */
+  body: Uint8Array;
+  /**
+   * Whether credential headers (e.g., Cookie) would have been included in this
+   * request. (They're never included in the headers property, because the
+   * browser doesn't expose them to JavaScript.) Note that the default fetch
+   * behavior makes this false, because the fake server only intercepts requests
+   * to .test domains, which are assumed to be cross-origin.
+   */
+  hasCredentials: boolean;
+}
+
+/**
+ * The parts of an HTTP fetch response that this library simulates. This is
+ * passed from callers in the `FakeServerHandler` callback type, so for caller
+ * convenience, callers can omit ones that aren't needed and can assume that
+ * they won't be needed.
+ */
+export interface FakeResponse {
+  /** Numeric status code (e.g., 200, 404). */
+  readonly status?: number;
+  /** Status message (e.g., OK, Not Found). */
+  readonly statusText?: string;
+  /**
+   * Response headers, excluding ones that the browser doesn't expose to
+   * JavaScript code like Set-Cookie. Names will be lowercased by the browser
+   * before being returned from fetch. A Content-Type header may be added by
+   * the browser if one isn't provided here, but only if there is a response
+   * body at all. Duplicate headers aren't supported.
+   */
+  readonly headers?: { readonly [name: string]: string };
+  /** Response body. Streaming isn't supported. */
+  readonly body?: string | Readonly<BufferSource>;
+}
+
+/** Headers that the browser automatically adds to requests. */
+export const DEFAULT_REQUEST_HEADERS: { readonly [name: string]: string } = {
+  "accept": "*/*",
+  "sec-ch-ua": "",
+  "sec-ch-ua-mobile": "?0",
+  "user-agent": navigator.userAgent,
+};
+
+/** Headers that the browser may automatically add to responses. */
+export const DEFAULT_RESPONSE_HEADERS: { readonly [name: string]: string } = {
+  "content-type": "text/plain;charset=UTF-8",
+};
 
 /** A callback that consumes an HTTP request and returns a response. */
-export type FakeServerHandler = (requestUrl: URL) => Promise<string>;
+export type FakeServerHandler = (request: FakeRequest) => Promise<FakeResponse>;
 
 let registration: ServiceWorkerRegistration;
 let port: MessagePort;
@@ -45,7 +115,7 @@ export function setFakeServerHandler(handler: FakeServerHandler): void {
 }
 
 function resetHandler() {
-  setFakeServerHandler(() => Promise.resolve(""));
+  setFakeServerHandler(() => Promise.resolve({}));
 }
 resetHandler();
 afterEach(resetHandler);
@@ -66,8 +136,38 @@ beforeAll(async () => {
   ]);
   await readyMessagePromise;
   port.onmessage = async ({ data, ports }: MessageEvent<unknown>) => {
-    assert(typeof data === "string");
-    ports[0].postMessage(await currentHandler(new URL(data)));
+    assert(isArray(data) && data.length === 5);
+    const [url, method, requestHeaders, requestBody, hasCredentials] = data;
+    assert(
+      typeof url === "string" &&
+        typeof method === "string" &&
+        Array.isArray(requestHeaders) &&
+        requestHeaders.every((header): header is [
+          name: string,
+          value: string
+        ] => {
+          if (!isArray(header) || header.length !== 2) {
+            return false;
+          }
+          const [name, value] = header;
+          return typeof name === "string" && typeof value === "string";
+        }) &&
+        requestBody instanceof ArrayBuffer &&
+        typeof hasCredentials === "boolean"
+    );
+    const {
+      status,
+      statusText,
+      headers: responseHeaders,
+      body: responseBody,
+    } = await currentHandler({
+      url: new URL(url),
+      method,
+      headers: Object.fromEntries(requestHeaders),
+      body: new Uint8Array(requestBody),
+      hasCredentials,
+    });
+    ports[0].postMessage([status, statusText, responseHeaders, responseBody]);
   };
 });
 

--- a/lib/shared/testing/http_test.ts
+++ b/lib/shared/testing/http_test.ts
@@ -5,33 +5,104 @@
  */
 
 import "jasmine";
-import { FakeServerHandler, setFakeServerHandler } from "./http";
+import {
+  DEFAULT_REQUEST_HEADERS,
+  DEFAULT_RESPONSE_HEADERS,
+  FakeRequest,
+  FakeServerHandler,
+  setFakeServerHandler,
+} from "./http";
 
 describe("setFakeServerHandler", () => {
   const url = "https://domain.test/path?key=value";
   const responseBody = "response body string";
 
   it("should respond to a fetch request with a custom handler", async () => {
+    const method = "POST";
+    const requestHeaders = { "name-1": "Value-1", "name-2": "Value-2" };
+    const requestBody = Uint8Array.of(1, 2, 3);
+    const status = 206;
+    const statusText = "Custom Status";
+    const responseHeaders = { "name-3": "Value-3", "name-4": "Value-4" };
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
-      .and.resolveTo(responseBody);
+      .and.resolveTo({
+        status,
+        statusText,
+        headers: responseHeaders,
+        body: responseBody,
+      });
     setFakeServerHandler(fakeServerHandler);
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      method,
+      headers: requestHeaders,
+      body: requestBody,
+      credentials: "include",
+    });
+    expect(response.ok).toBeTrue();
+    expect(response.status).toBe(status);
+    expect(response.statusText).toBe(statusText);
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      ...DEFAULT_RESPONSE_HEADERS,
+      ...responseHeaders,
+    });
     expect(await response.text()).toBe(responseBody);
-    expect(fakeServerHandler).toHaveBeenCalledOnceWith(new URL(url));
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith({
+      url: new URL(url),
+      method,
+      headers: {
+        ...DEFAULT_REQUEST_HEADERS,
+        ...requestHeaders,
+      },
+      body: requestBody,
+      hasCredentials: true,
+    });
+  });
+
+  it("should respond with a default empty response if not called", async () => {
+    const response = await fetch(url);
+    expect(response.ok).toBeTrue();
+    expect(response.status).toBe(200);
+    expect(response.statusText).toBe("");
+    expect(Object.fromEntries(response.headers.entries())).toEqual({});
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      Uint8Array.of()
+    );
+  });
+
+  it("should lowercase header names", async () => {
+    const headerValue = "Header value";
+    const fakeServerHandler = jasmine
+      .createSpy<FakeServerHandler>()
+      .and.resolveTo({ headers: { "a-ReSpOnSe-HeAdEr": headerValue } });
+    setFakeServerHandler(fakeServerHandler);
+    const response = await fetch(url, {
+      headers: { "a-ReQuEsT-hEaDeR": headerValue },
+    });
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      "a-response-header": headerValue,
+    });
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining<FakeRequest>({
+        headers: {
+          ...DEFAULT_REQUEST_HEADERS,
+          "a-request-header": headerValue,
+        },
+      })
+    );
   });
 
   for (const nth of ["first", "second"]) {
     it(`should respond with an empty body before handler is set (${nth} time)`, async () => {
       expect(await (await fetch(url)).text()).toEqual("");
-      setFakeServerHandler(() => Promise.resolve(responseBody));
+      setFakeServerHandler(() => Promise.resolve({ body: responseBody }));
       expect(await (await fetch(url)).text()).toEqual(responseBody);
     });
   }
 
   describe("with beforeEach", () => {
     beforeEach(() => {
-      setFakeServerHandler(() => Promise.resolve(responseBody));
+      setFakeServerHandler(() => Promise.resolve({ body: responseBody }));
     });
     it("should have set a handler", async () => {
       expect(await (await fetch(url)).text()).toEqual(responseBody);


### PR DESCRIPTION
Originally I was lazy and didn't add support for most HTTP metadata features like headers, but it turns out that we actually care about those.