### PR TITLE
Add more runtime validation to fetches

### DIFF
--- a/fake_server.js
+++ b/fake_server.js
@@ -43,7 +43,15 @@ onfetch = async (fetchEvent) => {
     new Promise((resolve) => {
       receiver.onmessage = ({ data: [status, statusText, headers, body] }) => {
         receiver.close();
-        resolve(new Response(body, { status, statusText, headers }));
+        const response = new Response(body, { status, statusText });
+        // The browser adds this by default when constructing a response with a
+        // body, but we want there to be no Content-Type header at all if one
+        // wasn't explicitly added, since this is how real servers are treated.
+        response.headers.delete("Content-Type");
+        for (const [name, value] of Object.entries(headers ?? {})) {
+          response.headers.append(name, value);
+        }
+        resolve(response);
       };
     })
   );

--- a/frame/auction.ts
+++ b/frame/auction.ts
@@ -75,6 +75,11 @@ async function fetchAndValidateTrustedScoringSignals(
     [...renderingUrls].map(encodeURIComponent).join(",")
   );
   const response = await tryFetchJson(url.href);
+  function logError(errorMessage: string) {
+    console.error(
+      `[FLEDGE Shim] Cannot use trusted scoring signals from ${url.href}: ${errorMessage}`
+    );
+  }
   switch (response.status) {
     case FetchJsonStatus.OK: {
       const signals = response.value;
@@ -86,16 +91,10 @@ async function fetchAndValidateTrustedScoringSignals(
     case FetchJsonStatus.NETWORK_ERROR:
       // Browser will have logged the error; no need to log it again.
       return;
-    case FetchJsonStatus.JSON_PARSE_ERROR:
+    case FetchJsonStatus.VALIDATION_ERROR:
       logError(response.errorMessage);
       return;
   }
-}
-
-function logError(errorMessage: string) {
-  console.error(
-    "[FLEDGE Shim] Invalid trusted scoring signals: " + errorMessage
-  );
 }
 
 function jsonTypeOf(value: unknown) {

--- a/frame/auction_test.ts
+++ b/frame/auction_test.ts
@@ -76,7 +76,13 @@ describe("runAdAuction", () => {
     ]);
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
-      .and.resolveTo({ body: '{"a": 1, "b": [true, null]}' });
+      .and.resolveTo({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: '{"a": 1, "b": [true, null]}',
+      });
     setFakeServerHandler(fakeServerHandler);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
     expect(fakeServerHandler).toHaveBeenCalledOnceWith(
@@ -96,6 +102,8 @@ describe("runAdAuction", () => {
             ],
           ]),
         }),
+        headers: jasmine.objectContaining({ "accept": "application/json" }),
+        hasCredentials: false,
       })
     );
   });
@@ -107,7 +115,13 @@ describe("runAdAuction", () => {
     ]);
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
-      .and.resolveTo({ body: '{"a": 1, "b": [true, null]}' });
+      .and.resolveTo({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: '{"a": 1, "b": [true, null]}',
+      });
     setFakeServerHandler(fakeServerHandler);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
     expect(fakeServerHandler).toHaveBeenCalledOnceWith(
@@ -127,6 +141,8 @@ describe("runAdAuction", () => {
             ],
           ]),
         }),
+        headers: jasmine.objectContaining({ "accept": "application/json" }),
+        hasCredentials: false,
       })
     );
   });
@@ -154,9 +170,20 @@ describe("runAdAuction", () => {
       [renderingUrl1, 0.01],
       [renderingUrl2, 0.02],
     ]);
-    setFakeServerHandler(() => Promise.resolve({ body: '{"a": 1?}' }));
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: '{"a": 1?}',
+      })
+    );
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
+    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
+      jasmine.stringMatching(/.*https:\/\/trusted-server\.test\/scoring.*/)
+    );
     expect(consoleSpy.error).toHaveBeenCalledOnceWith(
       // Illegal character is at position 7 in the string
       jasmine.stringMatching(/.*\b7\b.*/)
@@ -168,9 +195,20 @@ describe("runAdAuction", () => {
       [renderingUrl1, 0.01],
       [renderingUrl2, 0.02],
     ]);
-    setFakeServerHandler(() => Promise.resolve({ body: "3" }));
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: "3",
+      })
+    );
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
+    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
+      jasmine.stringMatching(/.*https:\/\/trusted-server\.test\/scoring.*/)
+    );
     expect(consoleSpy.error).toHaveBeenCalledOnceWith(
       jasmine.stringMatching(/.*\bnumber\b.*/)
     );
@@ -192,7 +230,13 @@ describe("runAdAuction", () => {
       [renderingUrl2, 0.02],
     ]);
     setFakeServerHandler(() =>
-      Promise.resolve({ body: '{"a": 1, "b": [true, null]}' })
+      Promise.resolve({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: '{"a": 1, "b": [true, null]}',
+      })
     );
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(trustedScoringSignalsUrl, hostname);

--- a/frame/fetch_test.ts
+++ b/frame/fetch_test.ts
@@ -6,7 +6,7 @@
 
 import "jasmine";
 import {
-  DEFAULT_REQUEST_HEADERS,
+  FakeRequest,
   FakeServerHandler,
   setFakeServerHandler,
 } from "../lib/shared/testing/http";
@@ -14,44 +14,118 @@ import { FetchJsonStatus, tryFetchJson } from "./fetch";
 
 describe("tryFetchJson", () => {
   const url = "https://json-endpoint.test/path";
-  const expectedRequest = {
-    url: new URL(url),
-    method: "GET",
-    headers: DEFAULT_REQUEST_HEADERS,
-    body: Uint8Array.of(),
-    hasCredentials: false,
+  const body = '{"a": 1, "b": [true, null]}';
+  const okResult = {
+    status: FetchJsonStatus.OK as const,
+    value: { "a": 1, "b": [true, null] },
   };
 
   it("should fetch a JSON value", async () => {
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
-      .and.resolveTo({ body: '{"a": 1, "b": [true, null]}' });
+      .and.resolveTo({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      });
     setFakeServerHandler(fakeServerHandler);
     const result = await tryFetchJson(url);
-    expect(result).toEqual({
-      status: FetchJsonStatus.OK,
-      value: { "a": 1, "b": [true, null] },
-    });
-    expect(fakeServerHandler).toHaveBeenCalledOnceWith(expectedRequest);
+    expect(result).toEqual(okResult);
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(url),
+        method: "GET",
+        headers: jasmine.objectContaining({
+          "accept": "application/json",
+        }),
+        body: Uint8Array.of(),
+        hasCredentials: false,
+      })
+    );
   });
 
-  it("should handle ill-formed JSON", async () => {
-    const fakeServerHandler = jasmine
-      .createSpy<FakeServerHandler>()
-      .and.resolveTo({ body: '{"a": 1?}' });
-    setFakeServerHandler(fakeServerHandler);
-    const result = await tryFetchJson(url);
-    expect(result).toEqual({
-      status: FetchJsonStatus.JSON_PARSE_ERROR,
+  it("should accept case-insensitive Content-Type", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "TeXt/JsOn; blah blah blah",
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      })
+    );
+    expect(await tryFetchJson(url)).toEqual(okResult);
+  });
+
+  it("should return a validation error on a wrong MIME type", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "TeXt/JsOn; blah blah blah",
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      })
+    );
+    expect(await tryFetchJson(url)).toEqual(okResult);
+  });
+
+  it("should return a validation error on a missing MIME type", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "TeXt/JsOn; blah blah blah",
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      })
+    );
+    expect(await tryFetchJson(url)).toEqual(okResult);
+  });
+
+  it("should return a validation error on ill-formed JSON", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: '{"a": 1?}',
+      })
+    );
+    expect(await tryFetchJson(url)).toEqual({
+      status: FetchJsonStatus.VALIDATION_ERROR,
       // Illegal character is at position 7 in the string
       errorMessage: jasmine.stringMatching(/.*\b7\b.*/),
     });
-    expect(fakeServerHandler).toHaveBeenCalledOnceWith(expectedRequest);
   });
 
   it("should handle a network error", async () => {
     expect(await tryFetchJson("invalid-scheme://")).toEqual({
       status: FetchJsonStatus.NETWORK_ERROR,
     });
+  });
+
+  it("should return a network error on redirect and not follow it", async () => {
+    const fakeServerHandler = jasmine
+      .createSpy<FakeServerHandler>()
+      .and.resolveTo({
+        status: 302,
+        headers: {
+          "Location": "https://json-endpoint.test/redirected",
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      });
+    setFakeServerHandler(fakeServerHandler);
+    expect(await tryFetchJson(url)).toEqual({
+      status: FetchJsonStatus.NETWORK_ERROR,
+    });
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining<FakeRequest>({ url: new URL(url) })
+    );
   });
 });

--- a/frame/handler_test.ts
+++ b/frame/handler_test.ts
@@ -99,12 +99,19 @@ describe("handleRequest", () => {
   });
 
   it("should run an ad auction", async () => {
+    const consoleSpy = spyOnAllFunctions(console);
     await handleRequest(joinMessageEvent, hostname);
     const { port1: receiver, port2: sender } = new MessageChannel();
     const messageEventPromise = awaitMessageToPort(receiver);
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
-      .and.resolveTo({ body: '{"a": 1, "b": [true, null]}' });
+      .and.resolveTo({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: '{"a": 1, "b": [true, null]}',
+      });
     setFakeServerHandler(fakeServerHandler);
     const trustedScoringSignalsUrl = "https://trusted-server.test/scoring";
     const auctionRequest: FledgeRequest = [
@@ -132,5 +139,6 @@ describe("handleRequest", () => {
         hasCredentials: false,
       })
     );
+    expect(consoleSpy.error).not.toHaveBeenCalled();
   });
 });

--- a/lib/shared/testing/http.ts
+++ b/lib/shared/testing/http.ts
@@ -80,19 +80,6 @@ export interface FakeResponse {
   readonly body?: string | Readonly<BufferSource>;
 }
 
-/** Headers that the browser automatically adds to requests. */
-export const DEFAULT_REQUEST_HEADERS: { readonly [name: string]: string } = {
-  "accept": "*/*",
-  "sec-ch-ua": "",
-  "sec-ch-ua-mobile": "?0",
-  "user-agent": navigator.userAgent,
-};
-
-/** Headers that the browser may automatically add to responses. */
-export const DEFAULT_RESPONSE_HEADERS: { readonly [name: string]: string } = {
-  "content-type": "text/plain;charset=UTF-8",
-};
-
 /** A callback that consumes an HTTP request and returns a response. */
 export type FakeServerHandler = (request: FakeRequest) => Promise<FakeResponse>;
 

--- a/lib/shared/testing/http_test.ts
+++ b/lib/shared/testing/http_test.ts
@@ -5,13 +5,7 @@
  */
 
 import "jasmine";
-import {
-  DEFAULT_REQUEST_HEADERS,
-  DEFAULT_RESPONSE_HEADERS,
-  FakeRequest,
-  FakeServerHandler,
-  setFakeServerHandler,
-} from "./http";
+import { FakeRequest, FakeServerHandler, setFakeServerHandler } from "./http";
 
 describe("setFakeServerHandler", () => {
   const url = "https://domain.test/path?key=value";
@@ -42,21 +36,19 @@ describe("setFakeServerHandler", () => {
     expect(response.ok).toBeTrue();
     expect(response.status).toBe(status);
     expect(response.statusText).toBe(statusText);
-    expect(Object.fromEntries(response.headers.entries())).toEqual({
-      ...DEFAULT_RESPONSE_HEADERS,
-      ...responseHeaders,
-    });
+    expect(Object.fromEntries(response.headers.entries())).toEqual(
+      responseHeaders
+    );
     expect(await response.text()).toBe(responseBody);
-    expect(fakeServerHandler).toHaveBeenCalledOnceWith({
-      url: new URL(url),
-      method,
-      headers: {
-        ...DEFAULT_REQUEST_HEADERS,
-        ...requestHeaders,
-      },
-      body: requestBody,
-      hasCredentials: true,
-    });
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(url),
+        method,
+        headers: jasmine.objectContaining(requestHeaders),
+        body: requestBody,
+        hasCredentials: true,
+      })
+    );
   });
 
   it("should respond with a default empty response if not called", async () => {
@@ -84,10 +76,7 @@ describe("setFakeServerHandler", () => {
     });
     expect(fakeServerHandler).toHaveBeenCalledOnceWith(
       jasmine.objectContaining<FakeRequest>({
-        headers: {
-          ...DEFAULT_REQUEST_HEADERS,
-          "a-request-header": headerValue,
-        },
+        headers: jasmine.objectContaining({ "a-request-header": headerValue }),
       })
     );
   });


### PR DESCRIPTION
The goal here is to mimic the behavior of https://source.chromium.org/chromium/chromium/src/+/main:content/services/auction_worklet/auction_downloader.cc. Charset validation isn't included because I think the browser automatically deals with that somehow when you call .json().