### PR TITLE
Introduce console logging utilities

### DIFF
--- a/frame/auction_test.ts
+++ b/frame/auction_test.ts
@@ -169,7 +169,7 @@ describe("runAdAuction", () => {
     expect(fakeServerHandler).not.toHaveBeenCalled();
   });
 
-  it("should log to console if MIME type is wrong", async () => {
+  it("should log a warning if MIME type is wrong", async () => {
     await setInterestGroupAds("interest group name", [
       [renderingUrl1, 0.01],
       [renderingUrl2, 0.02],
@@ -186,13 +186,15 @@ describe("runAdAuction", () => {
     );
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
-    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
+    expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
       jasmine.stringMatching(/.*https:\/\/trusted-server\.test\/scoring.*/),
+      jasmine.any(String),
       mimeType
     );
   });
 
-  it("should log to console if JSON is ill-formed", async () => {
+  it("should log a warning if JSON is ill-formed", async () => {
     await setInterestGroupAds("interest group name", [
       [renderingUrl1, 0.01],
       [renderingUrl2, 0.02],
@@ -208,16 +210,15 @@ describe("runAdAuction", () => {
     );
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
-    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
-      jasmine.stringMatching(/.*https:\/\/trusted-server\.test\/scoring.*/)
-    );
-    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
+    expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
+      jasmine.stringMatching(/.*https:\/\/trusted-server\.test\/scoring.*/),
       // Illegal character is at position 7 in the string
       jasmine.stringMatching(/.*\b7\b.*/)
     );
   });
 
-  it("should log to console if JSON value is not an object", async () => {
+  it("should log a warning if JSON value is not an object", async () => {
     await setInterestGroupAds("interest group name", [
       [renderingUrl1, 0.01],
       [renderingUrl2, 0.02],
@@ -233,15 +234,15 @@ describe("runAdAuction", () => {
     );
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
-    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
-      jasmine.stringMatching(/.*https:\/\/trusted-server\.test\/scoring.*/)
-    );
-    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
-      jasmine.stringMatching(/.*\bnumber\b.*/)
+    expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
+      jasmine.stringMatching(/.*https:\/\/trusted-server\.test\/scoring.*/),
+      jasmine.any(String),
+      3
     );
   });
 
-  it("should not log to console on network error", async () => {
+  it("should not log on network error", async () => {
     await setInterestGroupAds("interest group name", [
       [renderingUrl1, 0.01],
       [renderingUrl2, 0.02],
@@ -249,9 +250,10 @@ describe("runAdAuction", () => {
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction("invalid-scheme://", hostname);
     expect(consoleSpy.error).not.toHaveBeenCalled();
+    expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
 
-  it("should not log to console if trusted scoring signals are fetched successfully", async () => {
+  it("should not log if trusted scoring signals are fetched successfully", async () => {
     await setInterestGroupAds("interest group name", [
       [renderingUrl1, 0.01],
       [renderingUrl2, 0.02],
@@ -268,15 +270,17 @@ describe("runAdAuction", () => {
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
     expect(consoleSpy.error).not.toHaveBeenCalled();
+    expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
 
-  it("should not log to console if there are no ads", async () => {
+  it("should not log if there are no ads", async () => {
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(trustedScoringSignalsUrl, hostname);
     expect(consoleSpy.error).not.toHaveBeenCalled();
+    expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
 
-  it("should not log to console if no URL is provided", async () => {
+  it("should not log if no URL is provided", async () => {
     await setInterestGroupAds("interest group name", [
       [renderingUrl1, 0.01],
       [renderingUrl2, 0.02],
@@ -284,5 +288,6 @@ describe("runAdAuction", () => {
     const consoleSpy = spyOnAllFunctions(console);
     await runAdAuction(/* trustedScoringSignalsUrl= */ null, hostname);
     expect(consoleSpy.error).not.toHaveBeenCalled();
+    expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
 });

--- a/frame/console.ts
+++ b/frame/console.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Utilities for logging information to the console in the frame,
+ * for the benefit of developers trying to debug FLEDGE Shim or their
+ * integrations with it.
+ *
+ * In general, these APIs are used whenever the frame encounters an I/O error
+ * (including receiving invalid data) when communicating with something outside
+ * its direct control, such as the parent page, IndexedDB, or a URL where data
+ * is to be fetched from. Nothing is logged in the success path, and errors
+ * caused by bugs in the FLEDGE Shim frame itself are thrown as exceptions.
+ * (Integration bugs between the frame and the library can result in these kinds
+ * of logs, though, because the two components cannot trust one another.) In
+ * order to preserve confidentiality of FLEDGE Shim data, error messages from
+ * the frame are not exposed to the library; developers are instead advised to
+ * inspect the console logs.
+ */
+
+const prefix = "[FLEDGE Shim] ";
+
+/**
+ * Logs a console error. Used when an error occurs that makes it impossible to
+ * continue with the current operation.
+ */
+export function logError(message: string, data?: readonly unknown[]): void {
+  console.error(prefix + message, ...(data ?? []));
+}
+
+/**
+ * Logs a console warning. Used when an error occurs that can be recovered from.
+ */
+export function logWarning(message: string, data?: readonly unknown[]): void {
+  console.warn(prefix + message, ...(data ?? []));
+}

--- a/frame/console_test.ts
+++ b/frame/console_test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { logError, logWarning } from "./console";
+
+describe("logError", () => {
+  it("should log an error without associated data", () => {
+    const consoleSpy = spyOnAllFunctions(console);
+    logError("Message");
+    expect(consoleSpy.error).toHaveBeenCalledOnceWith("[FLEDGE Shim] Message");
+  });
+
+  it("should log an error with associated data", () => {
+    const consoleSpy = spyOnAllFunctions(console);
+    const data = Symbol();
+    logError("Message", [data]);
+    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
+      "[FLEDGE Shim] Message",
+      data
+    );
+  });
+});
+
+describe("logWarning", () => {
+  it("should log a warning without associated data", () => {
+    const consoleSpy = spyOnAllFunctions(console);
+    logWarning("Message");
+    expect(consoleSpy.warn).toHaveBeenCalledOnceWith("[FLEDGE Shim] Message");
+  });
+
+  it("should log a warning with associated data", () => {
+    const consoleSpy = spyOnAllFunctions(console);
+    const data = Symbol();
+    logWarning("Message", [data]);
+    expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
+      "[FLEDGE Shim] Message",
+      data
+    );
+  });
+});

--- a/frame/handler_test.ts
+++ b/frame/handler_test.ts
@@ -137,5 +137,6 @@ describe("handleRequest", () => {
       })
     );
     expect(consoleSpy.error).not.toHaveBeenCalled();
+    expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This should hopefully save a bit of code size and make things more consistent and testable.

As part of this change, problems with trusted signals now log warnings, not errors, since the auction can continue without trusted signals if it has to.