### PR TITLE
Use API request types throughout the codebase

### DIFF
--- a/frame/auction_test.ts
+++ b/frame/auction_test.ts
@@ -13,56 +13,43 @@ import {
 } from "../testing/http";
 import { clearStorageBeforeAndAfter } from "../testing/storage";
 import { runAdAuction } from "./auction";
-import { setInterestGroupAds } from "./db_schema";
+import { storeInterestGroup } from "./db_schema";
 
 describe("runAdAuction", () => {
   clearStorageBeforeAndAfter();
 
-  const renderingUrl1 = "about:blank#1";
-  const renderingUrl2 = "about:blank#2";
-  const renderingUrl3 = "about:blank#3";
-  const renderingUrl4 = "about:blank#4";
+  const name = "interest group name";
+  const ad1 = { renderingUrl: "about:blank#1", metadata: { price: 0.01 } };
+  const ad2 = { renderingUrl: "about:blank#2", metadata: { price: 0.02 } };
+  const ad3 = { renderingUrl: "about:blank#3", metadata: { price: 0.03 } };
+  const ad4 = { renderingUrl: "about:blank#4", metadata: { price: 0.04 } };
   const hostname = "www.example.com";
 
   it("should return the higher-priced ad from a single interest group", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
-    const token = await runAdAuction(
-      /* trustedScoringSignalsUrl= */ null,
-      hostname
-    );
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
+    const token = await runAdAuction({}, hostname);
     assertToBeString(token);
-    expect(sessionStorage.getItem(token)).toBe(renderingUrl2);
+    expect(sessionStorage.getItem(token)).toBe(ad2.renderingUrl);
   });
 
   it("should return the higher-priced ad across multiple interest groups", async () => {
-    await setInterestGroupAds("interest group 1", [[renderingUrl1, 0.01]]);
-    await setInterestGroupAds("interest group 2", [[renderingUrl2, 0.02]]);
-    const token = await runAdAuction(
-      /* trustedScoringSignalsUrl= */ null,
-      hostname
-    );
+    await storeInterestGroup({ name: "interest group name 1", ads: [ad1] });
+    await storeInterestGroup({ name: "interest group name 2", ads: [ad2] });
+    const token = await runAdAuction({}, hostname);
     assertToBeString(token);
-    expect(sessionStorage.getItem(token)).toBe(renderingUrl2);
+    expect(sessionStorage.getItem(token)).toBe(ad2.renderingUrl);
   });
 
   it("should return null if there are no ads", async () => {
-    const token = await runAdAuction(
-      /* trustedScoringSignalsUrl= */ null,
-      hostname
-    );
-    expect(token).toBeNull();
+    const result = await runAdAuction({}, hostname);
+    expect(result).toBeNull();
     expect(sessionStorage.length).toBe(0);
   });
 
   it("should return tokens in the expected format", async () => {
-    await setInterestGroupAds("interest group name", [[renderingUrl1, 0.02]]);
+    await storeInterestGroup({ name, ads: [ad1] });
     for (let i = 0; i < 100; i++) {
-      expect(
-        await runAdAuction(/* trustedScoringSignalsUrl= */ null, hostname)
-      ).toMatch(/^[0-9a-f]{32}$/);
+      expect(await runAdAuction({}, hostname)).toMatch(/^[0-9a-f]{32}$/);
     }
   });
 
@@ -77,15 +64,12 @@ describe("runAdAuction", () => {
   };
 
   it("should fetch trusted scoring signals for ads in a single interest group", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
       .and.resolveTo(trustedSignalsResponse);
     setFakeServerHandler(fakeServerHandler);
-    await runAdAuction(trustedScoringSignalsUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
     expect(fakeServerHandler).toHaveBeenCalledOnceWith(
       jasmine.objectContaining<FakeRequest>({
         url: new URL(
@@ -100,18 +84,15 @@ describe("runAdAuction", () => {
   });
 
   it("should fetch trusted scoring signals for ads across multiple interest groups", async () => {
-    await setInterestGroupAds("interest group 1", [[renderingUrl1, 0.01]]);
-    await setInterestGroupAds("interest group 2", [
-      [renderingUrl2, 0.02],
-      [renderingUrl3, 0.03],
-    ]);
-    await setInterestGroupAds("interest group 3", [[renderingUrl4, 0.04]]);
-    await setInterestGroupAds("interest group 4", []);
+    await storeInterestGroup({ name: "interest group 1", ads: [ad1] });
+    await storeInterestGroup({ name: "interest group 2", ads: [ad2, ad3] });
+    await storeInterestGroup({ name: "interest group 3", ads: [ad4] });
+    await storeInterestGroup({ name: "interest group 4", ads: [] });
     const fakeServerHandler = jasmine
       .createSpy<FakeServerHandler>()
       .and.resolveTo(trustedSignalsResponse);
     setFakeServerHandler(fakeServerHandler);
-    await runAdAuction(trustedScoringSignalsUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
     expect(fakeServerHandler).toHaveBeenCalledOnceWith(
       jasmine.objectContaining<FakeRequest>({
         url: new URL(
@@ -129,31 +110,25 @@ describe("runAdAuction", () => {
   it("should not fetch trusted scoring signals if there are no ads", async () => {
     const fakeServerHandler = jasmine.createSpy<FakeServerHandler>();
     setFakeServerHandler(fakeServerHandler);
-    await runAdAuction(trustedScoringSignalsUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
     expect(fakeServerHandler).not.toHaveBeenCalled();
   });
 
   it("should not fetch trusted scoring signals if no URL is provided", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     const fakeServerHandler = jasmine.createSpy<FakeServerHandler>();
     setFakeServerHandler(fakeServerHandler);
-    await runAdAuction(/* trustedScoringSignalsUrl= */ null, hostname);
+    await runAdAuction({}, hostname);
     expect(fakeServerHandler).not.toHaveBeenCalled();
   });
 
   it("should log a warning and not fetch trusted scoring signals if URL is ill-formed", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     const fakeServerHandler = jasmine.createSpy<FakeServerHandler>();
     setFakeServerHandler(fakeServerHandler);
     const consoleSpy = spyOnAllFunctions(console);
     const notUrl = "This string is not a URL.";
-    await runAdAuction(notUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl: notUrl }, hostname);
     expect(fakeServerHandler).not.toHaveBeenCalled();
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
       jasmine.any(String),
@@ -162,24 +137,18 @@ describe("runAdAuction", () => {
   });
 
   it("should log a warning and not fetch trusted scoring signals if URL has a query string", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     const fakeServerHandler = jasmine.createSpy<FakeServerHandler>();
     setFakeServerHandler(fakeServerHandler);
     const consoleSpy = spyOnAllFunctions(console);
     const url = trustedScoringSignalsUrl + "?key=value";
-    await runAdAuction(url, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl: url }, hostname);
     expect(fakeServerHandler).not.toHaveBeenCalled();
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(jasmine.any(String), url);
   });
 
   it("should log a warning if MIME type is wrong", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     const mimeType = "text/html";
     setFakeServerHandler(() =>
       Promise.resolve({
@@ -191,7 +160,7 @@ describe("runAdAuction", () => {
       })
     );
     const consoleSpy = spyOnAllFunctions(console);
-    await runAdAuction(trustedScoringSignalsUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
       jasmine.any(String),
       trustedScoringSignalsUrl + "?keys=about%3Ablank%231,about%3Ablank%232",
@@ -201,13 +170,10 @@ describe("runAdAuction", () => {
   });
 
   it("should log a warning if JSON is ill-formed", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     setFakeServerHandler(() => Promise.resolve({ headers, body: '{"a": 1?}' }));
     const consoleSpy = spyOnAllFunctions(console);
-    await runAdAuction(trustedScoringSignalsUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
       jasmine.any(String),
       trustedScoringSignalsUrl + "?keys=about%3Ablank%231,about%3Ablank%232",
@@ -217,10 +183,7 @@ describe("runAdAuction", () => {
   });
 
   it("should log a warning if JSON value is not an object", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     setFakeServerHandler(() =>
       Promise.resolve({
         headers,
@@ -228,7 +191,7 @@ describe("runAdAuction", () => {
       })
     );
     const consoleSpy = spyOnAllFunctions(console);
-    await runAdAuction(trustedScoringSignalsUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
       jasmine.any(String),
       trustedScoringSignalsUrl + "?keys=about%3Ablank%231,about%3Ablank%232",
@@ -238,42 +201,36 @@ describe("runAdAuction", () => {
   });
 
   it("should not log on network error", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     const consoleSpy = spyOnAllFunctions(console);
-    await runAdAuction("invalid-scheme://", hostname);
+    await runAdAuction(
+      { trustedScoringSignalsUrl: "invalid-scheme://" },
+      hostname
+    );
     expect(consoleSpy.error).not.toHaveBeenCalled();
     expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
 
   it("should not log if trusted scoring signals are fetched successfully", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     setFakeServerHandler(() => Promise.resolve(trustedSignalsResponse));
     const consoleSpy = spyOnAllFunctions(console);
-    await runAdAuction(trustedScoringSignalsUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
     expect(consoleSpy.error).not.toHaveBeenCalled();
     expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
 
   it("should not log if there are no ads", async () => {
     const consoleSpy = spyOnAllFunctions(console);
-    await runAdAuction(trustedScoringSignalsUrl, hostname);
+    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
     expect(consoleSpy.error).not.toHaveBeenCalled();
     expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
 
   it("should not log if no URL is provided", async () => {
-    await setInterestGroupAds("interest group name", [
-      [renderingUrl1, 0.01],
-      [renderingUrl2, 0.02],
-    ]);
+    await storeInterestGroup({ name, ads: [ad1, ad2] });
     const consoleSpy = spyOnAllFunctions(console);
-    await runAdAuction(/* trustedScoringSignalsUrl= */ null, hostname);
+    await runAdAuction({}, hostname);
     expect(consoleSpy.error).not.toHaveBeenCalled();
     expect(consoleSpy.warn).not.toHaveBeenCalled();
   });

--- a/frame/db_schema_test.ts
+++ b/frame/db_schema_test.ts
@@ -7,10 +7,9 @@
 import "jasmine";
 import { clearStorageBeforeAndAfter } from "../testing/storage";
 import {
-  Ad,
   deleteInterestGroup,
   getAllAds,
-  setInterestGroupAds,
+  storeInterestGroup,
 } from "./db_schema";
 import { useStore } from "./indexeddb";
 
@@ -19,47 +18,62 @@ describe("db_schema:", () => {
 
   describe("getAllAds", () => {
     it("should read an ad from IndexedDB", async () => {
-      const ads: Ad[] = [["about:blank", 0.02]];
-      await setInterestGroupAds("interest group name", ads);
+      const ads = [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }];
+      await storeInterestGroup({ name: "interest group name", ads });
       expect([...(await getAllAds())]).toEqual(ads);
     });
 
     it("should read ads from multiple entries in IndexedDB", async () => {
-      const ad1: Ad = ["about:blank#1", 0.01];
-      const ad2: Ad = ["about:blank#2", 0.02];
-      const ad3: Ad = ["about:blank#3", 0.03];
       await useStore("readwrite", (store) => {
-        store.add([ad1], "interest group name 1");
+        store.add([["about:blank#1", 0.01]], "interest group name 1");
         store.add([], "interest group name 2");
-        store.add([ad2, ad3], "interest group name 3");
+        store.add(
+          [
+            ["about:blank#2", 0.02],
+            ["about:blank#3", 0.03],
+          ],
+          "interest group name 3"
+        );
       });
-      expect([...(await getAllAds())]).toEqual([ad1, ad2, ad3]);
+      expect([...(await getAllAds())]).toEqual([
+        { renderingUrl: "about:blank#1", metadata: { price: 0.01 } },
+        { renderingUrl: "about:blank#2", metadata: { price: 0.02 } },
+        { renderingUrl: "about:blank#3", metadata: { price: 0.03 } },
+      ]);
     });
   });
 
-  describe("setInterestGroupAds", () => {
+  describe("storeInterestGroup", () => {
     it("should write an ad that can then be read", async () => {
       const name = "interest group name";
-      const ads: Ad[] = [["about:blank", 0.02]];
-      await setInterestGroupAds(name, ads);
+      const ads = [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }];
+      await storeInterestGroup({ name, ads });
       expect([...(await getAllAds())]).toEqual(ads);
     });
 
     it("should overwrite an existing ad", async () => {
       const name = "interest group name";
-      await setInterestGroupAds(name, [["about:blank#1", 0.01]]);
-      const ads: Ad[] = [["about:blank", 0.02]];
-      await setInterestGroupAds(name, ads);
+      await storeInterestGroup({
+        name,
+        ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+      });
+      const ads = [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }];
+      await storeInterestGroup({ name, ads });
       expect([...(await getAllAds())]).toEqual(ads);
     });
   });
 
-  describe("setInterestGroupAds", () => {
+  describe("deleteInterestGroup", () => {
     it("should delete an interest group whose ads then no longer appear", async () => {
-      const ads: Ad[] = [["about:blank#1", 0.01]];
-      await setInterestGroupAds("interest group name 1", ads);
+      const ads = [
+        { renderingUrl: "about:blank#1", metadata: { price: 0.01 } },
+      ];
+      await storeInterestGroup({ name: "interest group name 1", ads });
       const name = "interest group name 2";
-      await setInterestGroupAds(name, [["about:blank#2", 0.02]]);
+      await storeInterestGroup({
+        name,
+        ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
+      });
       await deleteInterestGroup(name);
       expect([...(await getAllAds())]).toEqual(ads);
     });


### PR DESCRIPTION
In order to facilitate this, rework protocol.ts to expose serialization and deserialization functions instead of type guards (except for the response type, which is simple enough not to need this).

Simultaneously rename setInterestGroupAds to storeInterestGroup, for clarity's sake.

This is the continuation of #100.