### PR TITLE
Replace getAllAds with forEachInterestGroup

### DIFF
--- a/frame/handler_test.ts
+++ b/frame/handler_test.ts
@@ -19,7 +19,7 @@ import {
   setFakeServerHandler,
 } from "../testing/http";
 import { clearStorageBeforeAndAfter } from "../testing/storage";
-import { getAllAds } from "./db_schema";
+import { forEachInterestGroup, InterestGroupCallback } from "./db_schema";
 import { handleRequest } from "./handler";
 
 describe("handleRequest", () => {
@@ -86,7 +86,9 @@ describe("handleRequest", () => {
 
   it("should join an interest group", async () => {
     await handleRequest(joinMessageEvent, hostname);
-    expect([...(await getAllAds())]).toEqual(ads);
+    const callback = jasmine.createSpy<InterestGroupCallback>();
+    await forEachInterestGroup(callback);
+    expect(callback).toHaveBeenCalledOnceWith(group);
   });
 
   it("should do nothing when joining an interest group with no ads", async () => {
@@ -100,7 +102,9 @@ describe("handleRequest", () => {
       }),
       hostname
     );
-    expect([...(await getAllAds())]).toEqual(ads);
+    const callback = jasmine.createSpy<InterestGroupCallback>();
+    await forEachInterestGroup(callback);
+    expect(callback).toHaveBeenCalledOnceWith(group);
   });
 
   it("should leave an interest group", async () => {
@@ -114,7 +118,9 @@ describe("handleRequest", () => {
       }),
       hostname
     );
-    expect([...(await getAllAds())]).toEqual([]);
+    const callback = jasmine.createSpy<InterestGroupCallback>();
+    await forEachInterestGroup(callback);
+    expect(callback).not.toHaveBeenCalled();
   });
 
   it("should run an ad auction", async () => {


### PR DESCRIPTION
For efficiency, this works by streaming over the entries in the database. We take a synchronous callback to guarantee that it can't block, which would be a problem because the browser will automatically close the IndexedDB transaction in that case. The resulting API is slightly awkward, but workable and hard to misuse.

While we're in here migrating stuff to the cursor API, do the same to storeInterestGroup, to faciliate partial updates. (We'll need these for dailyUpdateUrl even if we don't allow them in the JavaScript API.) This does not result in a change in observable behavior for now.