### PR TITLE
Make database operations return boolean success

### DIFF
--- a/frame/db_schema.ts
+++ b/frame/db_schema.ts
@@ -55,14 +55,14 @@ function recordFromInterestGroup(group: CanonicalInterestGroup) {
 }
 
 /**
- * Stores an interest group in IndexedDB. If there's already one with the same
- * name, each property value of the existing interest group is overwritten if
- * the new interest group has a defined value for that property, but left
- * unchanged if it does not. Note that there is no way to delete a property of
- * an existing interest group without overwriting it with a defined value or
- * deleting the whole interest group.
+ * Stores an interest group in IndexedDB and returns whether it was committed
+ * successfully. If there's already one with the same name, each property value
+ * of the existing interest group is overwritten if the new interest group has a
+ * defined value for that property, but left unchanged if it does not. Note that
+ * there is no way to delete a property of an existing interest group without
+ * overwriting it with a defined value or deleting the whole interest group.
  */
-export function storeInterestGroup(group: InterestGroup): Promise<void> {
+export function storeInterestGroup(group: InterestGroup): Promise<boolean> {
   return useStore("readwrite", (store) => {
     const { name } = group;
     const cursorRequest = store.openCursor(name);
@@ -98,10 +98,10 @@ export function storeInterestGroup(group: InterestGroup): Promise<void> {
 }
 
 /**
- * Deletes an interest group from IndexedDB. If there isn't one with the given
- * name, does nothing.
+ * Deletes an interest group from IndexedDB and returns whether it was committed
+ * successfully. If there isn't one with the given name, does nothing.
  */
-export function deleteInterestGroup(name: string): Promise<void> {
+export function deleteInterestGroup(name: string): Promise<boolean> {
   return useStore("readwrite", (store) => {
     store.delete(name);
   });
@@ -110,10 +110,13 @@ export function deleteInterestGroup(name: string): Promise<void> {
 /** Iteration callback type for `forEachInterestGroup`. */
 export type InterestGroupCallback = (group: CanonicalInterestGroup) => void;
 
-/** Iterates over all interest groups currently stored in IndexedDB. */
+/**
+ * Iterates over all interest groups currently stored in IndexedDB and returns
+ * whether they were all read successfully.
+ */
 export function forEachInterestGroup(
   callback: InterestGroupCallback
-): Promise<void> {
+): Promise<boolean> {
   return useStore("readonly", (store) => {
     const cursorRequest = store.openCursor();
     cursorRequest.onsuccess = () => {

--- a/frame/db_schema_test.ts
+++ b/frame/db_schema_test.ts
@@ -25,26 +25,28 @@ describe("db_schema:", () => {
         name,
         ads: [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }],
       };
-      await storeInterestGroup(group);
+      expect(await storeInterestGroup(group)).toBeTrue();
       const callback = jasmine.createSpy<InterestGroupCallback>();
-      await forEachInterestGroup(callback);
+      expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith(group);
     });
 
     it("should read multiple interest groups from IndexedDB", async () => {
-      await useStore("readwrite", (store) => {
-        store.add([["about:blank#1", 0.01]], "interest group name 1");
-        store.add([], "interest group name 2");
-        store.add(
-          [
-            ["about:blank#2", 0.02],
-            ["about:blank#3", 0.03],
-          ],
-          "interest group name 3"
-        );
-      });
+      expect(
+        await useStore("readwrite", (store) => {
+          store.add([["about:blank#1", 0.01]], "interest group name 1");
+          store.add([], "interest group name 2");
+          store.add(
+            [
+              ["about:blank#2", 0.02],
+              ["about:blank#3", 0.03],
+            ],
+            "interest group name 3"
+          );
+        })
+      ).toBeTrue();
       const callback = jasmine.createSpy<InterestGroupCallback>();
-      await forEachInterestGroup(callback);
+      expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledTimes(3);
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 1",
@@ -70,16 +72,16 @@ describe("db_schema:", () => {
         name,
         ads: [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }],
       };
-      await storeInterestGroup(group);
+      expect(await storeInterestGroup(group)).toBeTrue();
       const callback = jasmine.createSpy<InterestGroupCallback>();
-      await forEachInterestGroup(callback);
+      expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith(group);
     });
 
     it("should write an ad without all fields present", async () => {
-      await storeInterestGroup({ name });
+      expect(await storeInterestGroup({ name })).toBeTrue();
       const callback = jasmine.createSpy<InterestGroupCallback>();
-      await forEachInterestGroup(callback);
+      expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name,
         ads: [],
@@ -87,47 +89,55 @@ describe("db_schema:", () => {
     });
 
     it("should overwrite an existing ad", async () => {
-      await storeInterestGroup({
-        name,
-        ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
-      });
-      await storeInterestGroup({
-        name,
-        ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
-      });
+      expect(
+        await storeInterestGroup({
+          name,
+          ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+        })
+      ).toBeTrue();
+      expect(
+        await storeInterestGroup({
+          name,
+          ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
+        })
+      ).toBeTrue();
       const callback = jasmine.createSpy<InterestGroupCallback>();
-      await forEachInterestGroup(callback);
+      expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name,
         ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
       });
     });
+  });
 
-    describe("deleteInterestGroup", () => {
-      it("should delete an interest group", async () => {
+  describe("deleteInterestGroup", () => {
+    it("should delete an interest group", async () => {
+      expect(
         await storeInterestGroup({
           name: "interest group name 1",
           ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
-        });
+        })
+      ).toBeTrue();
+      expect(
         await storeInterestGroup({
           name: "interest group name 2",
           ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
-        });
-        await deleteInterestGroup("interest group name 2");
-        const callback = jasmine.createSpy<InterestGroupCallback>();
-        await forEachInterestGroup(callback);
-        expect(callback).toHaveBeenCalledOnceWith({
-          name: "interest group name 1",
-          ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
-        });
+        })
+      ).toBeTrue();
+      expect(await deleteInterestGroup("interest group name 2")).toBeTrue();
+      const callback = jasmine.createSpy<InterestGroupCallback>();
+      expect(await forEachInterestGroup(callback)).toBeTrue();
+      expect(callback).toHaveBeenCalledOnceWith({
+        name: "interest group name 1",
+        ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
+    });
 
-      it("should do nothing when deleting a nonexistent interest group", async () => {
-        await deleteInterestGroup("interest group name");
-        const callback = jasmine.createSpy<InterestGroupCallback>();
-        await forEachInterestGroup(callback);
-        expect(callback).not.toHaveBeenCalled();
-      });
+    it("should do nothing when deleting a nonexistent interest group", async () => {
+      expect(await deleteInterestGroup("interest group name")).toBeTrue();
+      const callback = jasmine.createSpy<InterestGroupCallback>();
+      expect(await forEachInterestGroup(callback)).toBeTrue();
+      expect(callback).not.toHaveBeenCalled();
     });
   });
 });

--- a/frame/handler.ts
+++ b/frame/handler.ts
@@ -38,9 +38,13 @@ export async function handleRequest(
     }
     switch (request.kind) {
       case RequestKind.JOIN_AD_INTEREST_GROUP:
+        // Ignore return value; any errors will have already been logged and
+        // there's nothing more to be done about them.
         await storeInterestGroup(request.group);
         return;
       case RequestKind.LEAVE_AD_INTEREST_GROUP:
+        // Ignore return value; any errors will have already been logged and
+        // there's nothing more to be done about them.
         await deleteInterestGroup(request.group.name);
         return;
       case RequestKind.RUN_AD_AUCTION: {
@@ -50,7 +54,17 @@ export async function handleRequest(
           );
         }
         const [port] = ports;
-        const token = await runAdAuction(request.config, hostname);
+        const result = await runAdAuction(request.config, hostname);
+        let token;
+        switch (result) {
+          case true:
+            token = null;
+            break;
+          case false:
+            throw new Error("IndexedDB error");
+          default:
+            token = result;
+        }
         const response: RunAdAuctionResponse = [true, token];
         port.postMessage(response);
         port.close();

--- a/frame/handler_test.ts
+++ b/frame/handler_test.ts
@@ -87,7 +87,7 @@ describe("handleRequest", () => {
   it("should join an interest group", async () => {
     await handleRequest(joinMessageEvent, hostname);
     const callback = jasmine.createSpy<InterestGroupCallback>();
-    await forEachInterestGroup(callback);
+    expect(await forEachInterestGroup(callback)).toBeTrue();
     expect(callback).toHaveBeenCalledOnceWith(group);
   });
 
@@ -103,7 +103,7 @@ describe("handleRequest", () => {
       hostname
     );
     const callback = jasmine.createSpy<InterestGroupCallback>();
-    await forEachInterestGroup(callback);
+    expect(await forEachInterestGroup(callback)).toBeTrue();
     expect(callback).toHaveBeenCalledOnceWith(group);
   });
 
@@ -119,7 +119,7 @@ describe("handleRequest", () => {
       hostname
     );
     const callback = jasmine.createSpy<InterestGroupCallback>();
-    await forEachInterestGroup(callback);
+    expect(await forEachInterestGroup(callback)).toBeTrue();
     expect(callback).not.toHaveBeenCalled();
   });
 

--- a/testing/storage.ts
+++ b/testing/storage.ts
@@ -23,7 +23,9 @@ export function clearStorageBeforeAndAfter(): void {
 
 async function clearStorage() {
   sessionStorage.clear();
-  await useStore("readwrite", (store) => {
-    store.clear();
-  });
+  expect(
+    await useStore("readwrite", (store) => {
+      store.clear();
+    })
+  ).toBeTrue();
 }

--- a/testing/storage_test.ts
+++ b/testing/storage_test.ts
@@ -28,19 +28,21 @@ describe("clearStorageBeforeAndAfter", () => {
       it(`should not already contain item when adding it (${nth} time)`, async () => {
         const value = "IndexedDB value";
         let retrieved: unknown;
-        await useStore("readwrite", (store) => {
-          const countRequest = store.count();
-          countRequest.onsuccess = () => {
-            expect(countRequest.result).toBe(0);
-            const key = "IndexedDB key";
-            store.add(value, key).onsuccess = () => {
-              const retrievalRequest = store.get(key);
-              retrievalRequest.onsuccess = () => {
-                retrieved = retrievalRequest.result;
+        expect(
+          await useStore("readwrite", (store) => {
+            const countRequest = store.count();
+            countRequest.onsuccess = () => {
+              expect(countRequest.result).toBe(0);
+              const key = "IndexedDB key";
+              store.add(value, key).onsuccess = () => {
+                const retrievalRequest = store.get(key);
+                retrievalRequest.onsuccess = () => {
+                  retrieved = retrievalRequest.result;
+                };
               };
             };
-          };
-        });
+          })
+        ).toBeTrue();
         expect(retrieved).toBe(value);
       });
     }


### PR DESCRIPTION
This is the first step of migrating the frame code (but not the library code) away from exceptions for circumstances that aren't bugs in the code (in particular, IndexedDB I/O errors). This will make the code more robust (since it's generally safe to assume that things won't throw) and facilitate error telemetry when we get to that point.