### PR TITLE
Add support for trusted bidding signals

### DIFF
--- a/frame/db_schema_test.ts
+++ b/frame/db_schema_test.ts
@@ -18,11 +18,13 @@ describe("db_schema:", () => {
   clearStorageBeforeAndAfter();
 
   const name = "interest group name";
+  const trustedBiddingSignalsUrl = "https://trusted-server.test/bidding";
 
   describe("forEachInterestGroup", () => {
     it("should read an interest group from IndexedDB", async () => {
       const group = {
         name,
+        trustedBiddingSignalsUrl,
         ads: [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }],
       };
       expect(await storeInterestGroup(group)).toBeTrue();
@@ -34,12 +36,21 @@ describe("db_schema:", () => {
     it("should read multiple interest groups from IndexedDB", async () => {
       expect(
         await useStore("readwrite", (store) => {
-          store.add([["about:blank#1", 0.01]], "interest group name 1");
-          store.add([], "interest group name 2");
+          store.add(
+            [trustedBiddingSignalsUrl, [["about:blank#1", 0.01]]],
+            "interest group name 1"
+          );
+          store.add(
+            ["https://trusted-server-2.test/bidding", []],
+            "interest group name 2"
+          );
           store.add(
             [
-              ["about:blank#2", 0.02],
-              ["about:blank#3", 0.03],
+              /* trustedBiddingSignalsUrl= */ undefined,
+              [
+                ["about:blank#2", 0.02],
+                ["about:blank#3", 0.03],
+              ],
             ],
             "interest group name 3"
           );
@@ -50,14 +61,17 @@ describe("db_schema:", () => {
       expect(callback).toHaveBeenCalledTimes(3);
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 1",
+        trustedBiddingSignalsUrl,
         ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 2",
+        trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
         ads: [],
       });
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 3",
+        trustedBiddingSignalsUrl: undefined,
         ads: [
           { renderingUrl: "about:blank#2", metadata: { price: 0.02 } },
           { renderingUrl: "about:blank#3", metadata: { price: 0.03 } },
@@ -70,6 +84,7 @@ describe("db_schema:", () => {
     it("should write an ad that can then be read", async () => {
       const group = {
         name,
+        trustedBiddingSignalsUrl,
         ads: [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }],
       };
       expect(await storeInterestGroup(group)).toBeTrue();
@@ -84,20 +99,23 @@ describe("db_schema:", () => {
       expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name,
+        trustedBiddingSignalsUrl: undefined,
         ads: [],
       });
     });
 
-    it("should overwrite an existing ad", async () => {
+    it("should overwrite all fields of an existing ad", async () => {
       expect(
         await storeInterestGroup({
           name,
+          trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
           ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
         })
       ).toBeTrue();
       expect(
         await storeInterestGroup({
           name,
+          trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
           ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
         })
       ).toBeTrue();
@@ -105,7 +123,31 @@ describe("db_schema:", () => {
       expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name,
+        trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
         ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
+      });
+    });
+
+    it("should overwrite some fields of an existing ad", async () => {
+      expect(
+        await storeInterestGroup({
+          name,
+          trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
+          ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+        })
+      ).toBeTrue();
+      expect(
+        await storeInterestGroup({
+          name,
+          trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
+        })
+      ).toBeTrue();
+      const callback = jasmine.createSpy<InterestGroupCallback>();
+      expect(await forEachInterestGroup(callback)).toBeTrue();
+      expect(callback).toHaveBeenCalledOnceWith({
+        name,
+        trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
+        ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
     });
   });
@@ -115,12 +157,14 @@ describe("db_schema:", () => {
       expect(
         await storeInterestGroup({
           name: "interest group name 1",
+          trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
           ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
         })
       ).toBeTrue();
       expect(
         await storeInterestGroup({
           name: "interest group name 2",
+          trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
           ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
         })
       ).toBeTrue();
@@ -129,6 +173,7 @@ describe("db_schema:", () => {
       expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name: "interest group name 1",
+        trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
         ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
     });

--- a/lib/public_api.ts
+++ b/lib/public_api.ts
@@ -129,6 +129,11 @@ export class FledgeShim {
    * If `group.name` is not the name of an existing interest group, a new
    * interest group is created.
    *
+   * A consequence of this is that it's possible to create an interest group
+   * with `trustedBiddingSignalsUrl: undefined`, but not to overwrite the
+   * `trustedBiddingSignalsUrl` of an existing interest group with `undefined`
+   * without deleting the entire interest group.
+   *
    * The second parameter from the FLEDGE spec (`duration`) is not yet
    * supported.
    *
@@ -138,7 +143,12 @@ export class FledgeShim {
   joinAdInterestGroup(group: InterestGroup): void {
     const messageData = messageDataFromRequest({
       kind: RequestKind.JOIN_AD_INTEREST_GROUP,
-      group,
+      group: {
+        ...group,
+        trustedBiddingSignalsUrl: absoluteTrustedSignalsUrl(
+          group.trustedBiddingSignalsUrl
+        ),
+      },
     });
     void this.getState().portPromise.then(
       (port) => {

--- a/lib/shared/api_types.ts
+++ b/lib/shared/api_types.ts
@@ -59,6 +59,11 @@ export interface InterestGroup {
    */
   name: string;
   /**
+   * An HTTPS URL with no query string. If provided, a request to this URL is
+   * made at auction time. The response is expected to be a JSON object.
+   */
+  trustedBiddingSignalsUrl?: string;
+  /**
    * Ads to be entered into the auction for impressions that this interest group
    * is permitted to bid on.
    */

--- a/lib/shared/protocol.ts
+++ b/lib/shared/protocol.ts
@@ -47,11 +47,17 @@ export function requestFromMessageData(
   const [kind] = messageData;
   switch (kind) {
     case RequestKind.JOIN_AD_INTEREST_GROUP: {
-      if (messageData.length !== 3) {
+      if (messageData.length !== 4) {
         return null;
       }
-      const [, name, adsMessageData] = messageData;
-      if (typeof name !== "string") {
+      const [, name, trustedBiddingSignalsUrl, adsMessageData] = messageData;
+      if (
+        !(
+          typeof name === "string" &&
+          (trustedBiddingSignalsUrl === undefined ||
+            typeof trustedBiddingSignalsUrl === "string")
+        )
+      ) {
         return null;
       }
       let ads;
@@ -72,7 +78,7 @@ export function requestFromMessageData(
       } else if (adsMessageData !== undefined) {
         return null;
       }
-      return { kind, group: { name, ads } };
+      return { kind, group: { name, trustedBiddingSignalsUrl, ads } };
     }
     case RequestKind.LEAVE_AD_INTEREST_GROUP: {
       if (messageData.length !== 2) {
@@ -110,11 +116,12 @@ export function messageDataFromRequest(request: FledgeRequest): unknown {
     case RequestKind.JOIN_AD_INTEREST_GROUP: {
       const {
         kind,
-        group: { name, ads },
+        group: { name, trustedBiddingSignalsUrl, ads },
       } = request;
       return [
         kind,
         name,
+        trustedBiddingSignalsUrl,
         ads?.map(({ renderingUrl, metadata: { price } }) => [
           renderingUrl,
           price,

--- a/lib/shared/protocol_test.ts
+++ b/lib/shared/protocol_test.ts
@@ -17,15 +17,16 @@ const requests: Array<{ request: FledgeRequest; messageData: unknown }> = [
   {
     request: {
       kind: RequestKind.JOIN_AD_INTEREST_GROUP,
-      group: { name: "", ads: undefined },
+      group: { name: "", trustedBiddingSignalsUrl: undefined, ads: undefined },
     },
-    messageData: [RequestKind.JOIN_AD_INTEREST_GROUP, "", undefined],
+    messageData: [RequestKind.JOIN_AD_INTEREST_GROUP, "", undefined, undefined],
   },
   {
     request: {
       kind: RequestKind.JOIN_AD_INTEREST_GROUP,
       group: {
         name: "interest group name",
+        trustedBiddingSignalsUrl: "https://trusted-server.example/bidding",
         ads: [
           { renderingUrl: "https://ad.example/1", metadata: { price: 0.02 } },
           { renderingUrl: "https://ad.example/2", metadata: { price: 0.04 } },
@@ -35,6 +36,7 @@ const requests: Array<{ request: FledgeRequest; messageData: unknown }> = [
     messageData: [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://trusted-server.example/bidding",
       [
         ["https://ad.example/1", 0.02],
         ["https://ad.example/2", 0.04],
@@ -86,20 +88,47 @@ describe("requestFromMessageData", () => {
     [],
     [true],
     [42],
-    [RequestKind.JOIN_AD_INTEREST_GROUP, "interest group name"],
-    [RequestKind.JOIN_AD_INTEREST_GROUP, "interest group name", [], 42],
-    [RequestKind.JOIN_AD_INTEREST_GROUP, [], []],
-    [RequestKind.JOIN_AD_INTEREST_GROUP, "interest group name", {}, []],
-    [RequestKind.JOIN_AD_INTEREST_GROUP, "interest group name", "nope"],
-    [RequestKind.JOIN_AD_INTEREST_GROUP, "interest group name", [null]],
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://trusted-server.example/bidding",
+    ],
+    [
+      RequestKind.JOIN_AD_INTEREST_GROUP,
+      "interest group name",
+      "https://trusted-server.example/bidding",
+      [],
+      42,
+    ],
+    [
+      RequestKind.JOIN_AD_INTEREST_GROUP,
+      [],
+      "https://trusted-server.example/bidding",
+      [],
+    ],
+    [RequestKind.JOIN_AD_INTEREST_GROUP, "interest group name", {}, []],
+    [
+      RequestKind.JOIN_AD_INTEREST_GROUP,
+      "interest group name",
+      "https://trusted-server.example/bidding",
+      "nope",
+    ],
+    [
+      RequestKind.JOIN_AD_INTEREST_GROUP,
+      "interest group name",
+      "https://trusted-server.example/bidding",
+      [null],
+    ],
+    [
+      RequestKind.JOIN_AD_INTEREST_GROUP,
+      "interest group name",
+      "https://trusted-server.example/bidding",
       [["https://ad.example/1", 0.02], []],
     ],
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://trusted-server.example/bidding",
       [
         ["https://ad.example/1", 0.02, true],
         ["https://ad.example/2", 0.04],
@@ -108,6 +137,7 @@ describe("requestFromMessageData", () => {
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://trusted-server.example/bidding",
       [
         ["https://ad.example/1", 0.02],
         ["https://ad.example/2", 0.04],
@@ -117,6 +147,7 @@ describe("requestFromMessageData", () => {
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://trusted-server.example/bidding",
       [
         ["https://ad.example/1", 0.02],
         ["https://ad.example/2", "nope"],
@@ -157,6 +188,7 @@ describe("messageDataFromRequest", () => {
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
       undefined,
+      undefined,
     ]);
   });
 
@@ -166,6 +198,7 @@ describe("messageDataFromRequest", () => {
         kind: RequestKind.LEAVE_AD_INTEREST_GROUP,
         group: {
           name: "interest group name",
+          trustedBiddingSignalsUrl: "https://trusted-server.example/bidding",
           ads: [
             { renderingUrl: "https://ad.example/1", metadata: { price: 0.02 } },
             { renderingUrl: "https://ad.example/2", metadata: { price: 0.04 } },


### PR DESCRIPTION
keys aren't included yet, because I had figured that they'd depend on the choice of hardcoded algorithm. That's no longer the plan, so they'll be added shortly.

Fixes: #22