### PR TITLE
Don't broadcast error responses to every port

### DIFF
--- a/frame/handler.ts
+++ b/frame/handler.ts
@@ -62,15 +62,12 @@ export async function handleRequest(
           throw new Error("IndexedDB error");
         }
         port.postMessage(response);
-        port.close();
         return;
       }
     }
-  } catch (error: unknown) {
-    const response: RunAdAuctionResponse = false;
+  } finally {
     for (const port of ports) {
-      port.postMessage(response);
+      port.close();
     }
-    throw error;
   }
 }

--- a/frame/handler_test.ts
+++ b/frame/handler_test.ts
@@ -35,7 +35,7 @@ describe("handleRequest", () => {
     [RequestKind.LEAVE_AD_INTEREST_GROUP, 0.02],
     [RequestKind.RUN_AD_AUCTION, []],
   ]) {
-    it(`should reply with error message to ${JSON.stringify(
+    it(`should throw and not reply to ${JSON.stringify(
       badInput
     )}`, async () => {
       const { port1: receiver, port2: sender } = new MessageChannel();
@@ -46,27 +46,7 @@ describe("handleRequest", () => {
           hostname
         )
       ).toBeRejectedWithError();
-      expect((await messageEventPromise).data).toBeFalse();
-    });
-
-    it(`should reply with error message on multiple ports to ${JSON.stringify(
-      badInput
-    )}`, async () => {
-      const { port1: receiver1, port2: sender1 } = new MessageChannel();
-      const messageEventPromise1 = awaitMessageToPort(receiver1);
-      const { port1: receiver2, port2: sender2 } = new MessageChannel();
-      const messageEventPromise2 = awaitMessageToPort(receiver2);
-      await expectAsync(
-        handleRequest(
-          new MessageEvent("message", {
-            data: badInput,
-            ports: [sender1, sender2],
-          }),
-          hostname
-        )
-      ).toBeRejectedWithError();
-      expect((await messageEventPromise1).data).toBeFalse();
-      expect((await messageEventPromise2).data).toBeFalse();
+      await expectAsync(messageEventPromise).toBePending();
     });
   }
 


### PR DESCRIPTION
This seemed like a vaguely good idea at the time, but it's actually just kind of weird and unnecessary. Only send an error response if we know that a response is expected.