### PR TITLE
Return null instead of throwing on messageerror

### DIFF
--- a/frame/handler_test.ts
+++ b/frame/handler_test.ts
@@ -11,7 +11,11 @@ import {
   messageDataFromRequest,
   RequestKind,
 } from "../lib/shared/protocol";
-import { assertToBeString, assertToSatisfyTypeGuard } from "../testing/assert";
+import {
+  assertToBeString,
+  assertToBeTruthy,
+  assertToSatisfyTypeGuard,
+} from "../testing/assert";
 import {
   FakeRequest,
   FakeServerHandler,
@@ -135,7 +139,9 @@ describe("handleRequest", () => {
       }),
       hostname
     );
-    const { data } = await messageEventPromise;
+    const event = await messageEventPromise;
+    assertToBeTruthy(event);
+    const { data } = event;
     assertToSatisfyTypeGuard(data, isRunAdAuctionResponse);
     assertToBeString(data);
     expect(sessionStorage.getItem(data)).toBe(renderingUrl);

--- a/frame/main_test.ts
+++ b/frame/main_test.ts
@@ -36,10 +36,11 @@ describe("main", () => {
     const handshakeMessageEventPromise = awaitMessageFromSelfToSelf();
     assertToBeTruthy(iframe.contentWindow);
     main(iframe.contentWindow);
-    const { data: handshakeData, ports } = await handshakeMessageEventPromise;
-    expect(handshakeData).toEqual({ [VERSION_KEY]: VERSION });
-    expect(ports).toHaveSize(1);
-    const [port] = ports;
+    const handshakeMessageEvent = await handshakeMessageEventPromise;
+    assertToBeTruthy(handshakeMessageEvent);
+    expect(handshakeMessageEvent.data).toEqual({ [VERSION_KEY]: VERSION });
+    expect(handshakeMessageEvent.ports).toHaveSize(1);
+    const [port] = handshakeMessageEvent.ports;
     port.postMessage(
       messageDataFromRequest({
         kind: RequestKind.JOIN_AD_INTEREST_GROUP,
@@ -55,7 +56,9 @@ describe("main", () => {
       messageDataFromRequest({ kind: RequestKind.RUN_AD_AUCTION, config: {} }),
       [sender]
     );
-    const { data: auctionResponse } = await auctionMessageEventPromise;
+    const auctionMessageEvent = await auctionMessageEventPromise;
+    assertToBeTruthy(auctionMessageEvent);
+    const { data: auctionResponse } = auctionMessageEvent;
     assertToSatisfyTypeGuard(auctionResponse, isRunAdAuctionResponse);
     assertToBeString(auctionResponse);
     expect(sessionStorage.getItem(auctionResponse)).toBe(renderingUrl);

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -37,7 +37,11 @@ export async function awaitConnectionFromIframe(
   iframe: HTMLIFrameElement,
   expectedOrigin: string
 ): Promise<MessagePort> {
-  const { data, ports, origin } = await awaitMessageFromIframeToSelf(iframe);
+  const event = await awaitMessageFromIframeToSelf(iframe);
+  if (!event) {
+    throw new Error("Message deserialization error");
+  }
+  const { data, ports, origin } = event;
   if (origin !== expectedOrigin) {
     throw new Error(
       `Origin mismatch during handshake: expected ${expectedOrigin}, but received ${origin}`

--- a/lib/public_api.ts
+++ b/lib/public_api.ts
@@ -229,7 +229,11 @@ export class FledgeShim {
     try {
       const eventPromise = awaitMessageToPort(receiver);
       mainPort.postMessage(messageData, [sender]);
-      const { data } = await eventPromise;
+      const event = await eventPromise;
+      if (!event) {
+        throw new Error("Message deserialization error");
+      }
+      const { data } = event;
       if (!isRunAdAuctionResponse(data)) {
         throw new Error(
           `Malformed response: expected RunAdAuctionResponse, but received ${JSON.stringify(

--- a/lib/shared/messaging.ts
+++ b/lib/shared/messaging.ts
@@ -8,29 +8,31 @@
 
 /**
  * Returns a promise that resolves to the first `MessageEvent` sent from
- * `iframe`'s content window to the current window.
+ * `iframe`'s content window to the current window, or to null if a
+ * deserialization error occurs.
  */
 export function awaitMessageFromIframeToSelf(
   iframe: HTMLIFrameElement
-): Promise<MessageEvent<unknown>> {
+): Promise<MessageEvent<unknown> | null> {
   return awaitMessage(window, ({ source }) => source === iframe.contentWindow);
 }
 
 /**
  * Returns a promise that resolves to the first `MessageEvent` sent from the
- * current window to itself.
+ * current window to itself, or to null if a deserialization error occurs.
  */
-export function awaitMessageFromSelfToSelf(): Promise<MessageEvent<unknown>> {
+export function awaitMessageFromSelfToSelf(): Promise<MessageEvent<unknown> | null> {
   return awaitMessage(window, ({ source }) => source === window);
 }
 
 /**
  * Returns a promise that resolves to the first `MessageEvent` sent to `port`,
- * which is activated if it hasn't been already.
+ * which is activated if it hasn't been already, or to null if a deserialization
+ * error occurs.
  */
 export function awaitMessageToPort(
   port: MessagePort
-): Promise<MessageEvent<unknown>> {
+): Promise<MessageEvent<unknown> | null> {
   const messageEventPromise = awaitMessage(port, () => true);
   port.start();
   return messageEventPromise;
@@ -40,7 +42,7 @@ function awaitMessage(
   target: MessageTarget,
   filter: (event: MessageEvent<unknown>) => boolean
 ) {
-  return new Promise<MessageEvent<unknown>>((resolve, reject) => {
+  return new Promise<MessageEvent<unknown> | null>((resolve) => {
     const messageListener = (event: MessageEvent<unknown>) => {
       if (filter(event)) {
         target.removeEventListener("message", messageListener);
@@ -52,7 +54,7 @@ function awaitMessage(
       if (filter(event)) {
         target.removeEventListener("message", messageListener);
         target.removeEventListener("messageerror", messageErrorListener);
-        reject(new Error("Message deserialization error"));
+        resolve(null);
       }
     };
     target.addEventListener("message", messageListener);

--- a/lib/shared/messaging_test.ts
+++ b/lib/shared/messaging_test.ts
@@ -5,6 +5,7 @@
  */
 
 import "jasmine";
+import { assertToBeTruthy } from "../../testing/assert";
 import { cleanDomAfterEach } from "../../testing/dom";
 import {
   addMessagePortMatchers,
@@ -29,7 +30,9 @@ describe("messaging:", () => {
       const payload = crypto.getRandomValues(new Int32Array(1))[0];
       const { port1, port2 } = new MessageChannel();
       postMessageFromIframeToSelf(iframe, payload, [port1]);
-      const { data, origin, ports, source } = await messageEventPromise;
+      const messageEvent = await messageEventPromise;
+      assertToBeTruthy(messageEvent);
+      const { data, origin, ports, source } = messageEvent;
       expect(data).toBe(payload);
       expect(origin).toBe(window.origin);
       expect(ports).toHaveSize(1);
@@ -60,13 +63,13 @@ describe("messaging:", () => {
     const POSTMESSAGE_WASM_MODULE_SRCDOC =
       "<!DOCTYPE html><title>Helper</title><script>parent.postMessage(new WebAssembly.Module(Uint8Array.of(0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00)), '*');</script>";
 
-    it("should reject on message error", async () => {
+    it("should return null on message error", async () => {
       const iframe = document.createElement("iframe");
       iframe.srcdoc = POSTMESSAGE_WASM_MODULE_SRCDOC;
       iframe.sandbox.add("allow-scripts");
       const messageEventPromise = awaitMessageFromIframeToSelf(iframe);
       document.body.appendChild(iframe);
-      await expectAsync(messageEventPromise).toBeRejectedWithError();
+      expect(await messageEventPromise).toBeNull();
     });
 
     it("should ignore message errors from other windows", async () => {
@@ -91,7 +94,9 @@ describe("messaging:", () => {
       const payload = crypto.getRandomValues(new Int32Array(1))[0];
       const { port1, port2 } = new MessageChannel();
       postMessage(payload, window.origin, [port1]);
-      const { data, origin, ports, source } = await messageEventPromise;
+      const messageEvent = await messageEventPromise;
+      assertToBeTruthy(messageEvent);
+      const { data, origin, ports, source } = messageEvent;
       expect(data).toBe(payload);
       expect(origin).toBe(window.origin);
       expect(ports).toHaveSize(1);
@@ -117,7 +122,9 @@ describe("messaging:", () => {
       const payload = crypto.getRandomValues(new Int32Array(1))[0];
       const { port1, port2 } = new MessageChannel();
       sender.postMessage(payload, [port1]);
-      const { data, ports } = await messageEventPromise;
+      const messageEvent = await messageEventPromise;
+      assertToBeTruthy(messageEvent);
+      const { data, ports } = messageEvent;
       expect(data).toBe(payload);
       expect(ports).toHaveSize(1);
       await expectAsync(ports[0]).toBeEntangledWith(port2);

--- a/testing/messaging.ts
+++ b/testing/messaging.ts
@@ -45,7 +45,9 @@ export function addMessagePortMatchers(): void {
         expected.postMessage(payload);
         return {
           pass: await Promise.race([
-            messageEventPromise.then(({ data }) => data === payload),
+            messageEventPromise.then(
+              (event) => event !== null && event.data === payload
+            ),
             new Promise<false>((resolve) => {
               setTimeout(() => {
                 resolve(false);


### PR DESCRIPTION
This continues the move away from flow-control exceptions in the frame started in #108.