### PR TITLE
Turn on CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,21 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: 23 10 * * 1
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: github/codeql-action/init@v1
+        with:
+          languages: javascript
+      - uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
This is a feature offered by GitHub that tries to statically analyze our code for security vulnerabilities. I don't really know how good it is, but turning it on silences a warning/suggestion in the Security tab, so we might as well see what it does.