### PR TITLE
Rename APIs to match Chrome's implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ all.
 The `auctionWinnerUrl` will be the same URL as the FLEDGE Shim frame, with a
 randomly generated token appended in the fragment. When rendered with such a
 token in its URL fragment, the FLEDGE Shim frame will create a nested iframe
-inside itself pointing at the original `renderingUrl`. This only works from the
+inside itself pointing at the original `renderUrl`. This only works from the
 same page that called `runAdAuction`.
 
 ### Worklets

--- a/frame/auction.ts
+++ b/frame/auction.ts
@@ -6,7 +6,7 @@
 
 /** @fileoverview Selection of ads, and creation of tokens to display them. */
 
-import { Ad, AuctionAdConfig } from "../lib/shared/api_types";
+import { AuctionAd, AuctionAdConfig } from "../lib/shared/api_types";
 import { isKeyValueObject } from "../lib/shared/guards";
 import { logWarning } from "./console";
 import { forEachInterestGroup } from "./db_schema";
@@ -40,16 +40,16 @@ export async function runAdAuction(
   { trustedScoringSignalsUrl }: AuctionAdConfig,
   hostname: string
 ): Promise<string | boolean> {
-  let winner: Ad | undefined;
+  let winner: AuctionAd | undefined;
   const trustedBiddingSignalsUrls = new Set<string>();
-  const renderingUrls = new Set<string>();
+  const renderUrls = new Set<string>();
   if (
     !(await forEachInterestGroup(({ trustedBiddingSignalsUrl, ads }) => {
       if (trustedBiddingSignalsUrl !== undefined && ads.length) {
         trustedBiddingSignalsUrls.add(trustedBiddingSignalsUrl);
       }
       for (const ad of ads) {
-        renderingUrls.add(ad.renderingUrl);
+        renderUrls.add(ad.renderUrl);
         if (!winner || ad.metadata.price > winner.metadata.price) {
           winner = ad;
         }
@@ -73,13 +73,13 @@ export async function runAdAuction(
       if (trustedScoringSignalsUrl !== undefined) {
         yield fetchAndValidateTrustedSignals(
           trustedScoringSignalsUrl,
-          `keys=${[...renderingUrls].map(encodeURIComponent).join(",")}`
+          `keys=${[...renderUrls].map(encodeURIComponent).join(",")}`
         );
       }
     })()
   );
   const token = randomToken();
-  sessionStorage.setItem(token, winner.renderingUrl);
+  sessionStorage.setItem(token, winner.renderUrl);
   return token;
 }
 

--- a/frame/auction_test.ts
+++ b/frame/auction_test.ts
@@ -19,17 +19,17 @@ describe("runAdAuction", () => {
   clearStorageBeforeAndAfter();
 
   const name = "interest group name";
-  const ad1 = { renderingUrl: "about:blank#1", metadata: { price: 0.01 } };
-  const ad2 = { renderingUrl: "about:blank#2", metadata: { price: 0.02 } };
-  const ad3 = { renderingUrl: "about:blank#3", metadata: { price: 0.03 } };
-  const ad4 = { renderingUrl: "about:blank#4", metadata: { price: 0.04 } };
+  const ad1 = { renderUrl: "about:blank#1", metadata: { price: 0.01 } };
+  const ad2 = { renderUrl: "about:blank#2", metadata: { price: 0.02 } };
+  const ad3 = { renderUrl: "about:blank#3", metadata: { price: 0.03 } };
+  const ad4 = { renderUrl: "about:blank#4", metadata: { price: 0.04 } };
   const hostname = "www.example.com";
 
   it("should return the higher-priced ad from a single interest group", async () => {
     expect(await storeInterestGroup({ name, ads: [ad1, ad2] })).toBeTrue();
     const token = await runAdAuction({}, hostname);
     assertToBeString(token);
-    expect(sessionStorage.getItem(token)).toBe(ad2.renderingUrl);
+    expect(sessionStorage.getItem(token)).toBe(ad2.renderUrl);
   });
 
   it("should return the higher-priced ad across multiple interest groups", async () => {
@@ -41,7 +41,7 @@ describe("runAdAuction", () => {
     ).toBeTrue();
     const token = await runAdAuction({}, hostname);
     assertToBeString(token);
-    expect(sessionStorage.getItem(token)).toBe(ad2.renderingUrl);
+    expect(sessionStorage.getItem(token)).toBe(ad2.renderUrl);
   });
 
   it("should return true if there are no ads", async () => {

--- a/frame/db_schema.ts
+++ b/frame/db_schema.ts
@@ -9,7 +9,7 @@
  * IndexedDB, with runtime type checking.
  */
 
-import { Ad, InterestGroup } from "../lib/shared/api_types";
+import { AuctionAd, AuctionAdInterestGroup } from "../lib/shared/api_types";
 import { isArray } from "../lib/shared/guards";
 import { logWarning } from "./console";
 import { useStore } from "./indexeddb";
@@ -21,7 +21,7 @@ import { useStore } from "./indexeddb";
 export interface CanonicalInterestGroup {
   name: string;
   trustedBiddingSignalsUrl: string | undefined;
-  ads: Ad[];
+  ads: AuctionAd[];
 }
 
 function interestGroupFromRecord(record: unknown, key: IDBValidKey) {
@@ -47,11 +47,11 @@ function interestGroupFromRecord(record: unknown, key: IDBValidKey) {
     if (!(isArray(adRecord) && adRecord.length === 2)) {
       return handleMalformedEntry();
     }
-    const [renderingUrl, price] = adRecord;
-    if (!(typeof renderingUrl === "string" && typeof price === "number")) {
+    const [renderUrl, price] = adRecord;
+    if (!(typeof renderUrl === "string" && typeof price === "number")) {
       return handleMalformedEntry();
     }
-    ads.push({ renderingUrl, metadata: { price } });
+    ads.push({ renderUrl, metadata: { price } });
   }
   return { name: key, trustedBiddingSignalsUrl, ads };
 }
@@ -60,8 +60,8 @@ function recordFromInterestGroup(group: CanonicalInterestGroup) {
   return [
     group.trustedBiddingSignalsUrl,
     group.ads
-      ? group.ads.map(({ renderingUrl, metadata: { price } }) => [
-          renderingUrl,
+      ? group.ads.map(({ renderUrl, metadata: { price } }) => [
+          renderUrl,
           price,
         ])
       : [],
@@ -76,7 +76,9 @@ function recordFromInterestGroup(group: CanonicalInterestGroup) {
  * there is no way to delete a property of an existing interest group without
  * overwriting it with a defined value or deleting the whole interest group.
  */
-export function storeInterestGroup(group: InterestGroup): Promise<boolean> {
+export function storeInterestGroup(
+  group: AuctionAdInterestGroup
+): Promise<boolean> {
   return useStore("readwrite", (store) => {
     const { name } = group;
     const cursorRequest = store.openCursor(name);

--- a/frame/db_schema_test.ts
+++ b/frame/db_schema_test.ts
@@ -25,7 +25,7 @@ describe("db_schema:", () => {
       const group = {
         name,
         trustedBiddingSignalsUrl,
-        ads: [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }],
+        ads: [{ renderUrl: "about:blank", metadata: { price: 0.02 } }],
       };
       expect(await storeInterestGroup(group)).toBeTrue();
       const callback = jasmine.createSpy<InterestGroupCallback>();
@@ -62,7 +62,7 @@ describe("db_schema:", () => {
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 1",
         trustedBiddingSignalsUrl,
-        ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+        ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 2",
@@ -73,8 +73,8 @@ describe("db_schema:", () => {
         name: "interest group name 3",
         trustedBiddingSignalsUrl: undefined,
         ads: [
-          { renderingUrl: "about:blank#2", metadata: { price: 0.02 } },
-          { renderingUrl: "about:blank#3", metadata: { price: 0.03 } },
+          { renderUrl: "about:blank#2", metadata: { price: 0.02 } },
+          { renderUrl: "about:blank#3", metadata: { price: 0.03 } },
         ],
       });
     });
@@ -85,7 +85,7 @@ describe("db_schema:", () => {
       const group = {
         name,
         trustedBiddingSignalsUrl,
-        ads: [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }],
+        ads: [{ renderUrl: "about:blank", metadata: { price: 0.02 } }],
       };
       expect(await storeInterestGroup(group)).toBeTrue();
       const callback = jasmine.createSpy<InterestGroupCallback>();
@@ -109,14 +109,14 @@ describe("db_schema:", () => {
         await storeInterestGroup({
           name,
           trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
-          ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+          ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
         })
       ).toBeTrue();
       expect(
         await storeInterestGroup({
           name,
           trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
-          ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
+          ads: [{ renderUrl: "about:blank#2", metadata: { price: 0.02 } }],
         })
       ).toBeTrue();
       const callback = jasmine.createSpy<InterestGroupCallback>();
@@ -124,7 +124,7 @@ describe("db_schema:", () => {
       expect(callback).toHaveBeenCalledOnceWith({
         name,
         trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
-        ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
+        ads: [{ renderUrl: "about:blank#2", metadata: { price: 0.02 } }],
       });
     });
 
@@ -133,7 +133,7 @@ describe("db_schema:", () => {
         await storeInterestGroup({
           name,
           trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
-          ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+          ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
         })
       ).toBeTrue();
       expect(
@@ -147,7 +147,7 @@ describe("db_schema:", () => {
       expect(callback).toHaveBeenCalledOnceWith({
         name,
         trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
-        ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+        ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
     });
   });
@@ -158,14 +158,14 @@ describe("db_schema:", () => {
         await storeInterestGroup({
           name: "interest group name 1",
           trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
-          ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+          ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
         })
       ).toBeTrue();
       expect(
         await storeInterestGroup({
           name: "interest group name 2",
           trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
-          ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.02 } }],
+          ads: [{ renderUrl: "about:blank#2", metadata: { price: 0.02 } }],
         })
       ).toBeTrue();
       expect(await deleteInterestGroup("interest group name 2")).toBeTrue();
@@ -174,7 +174,7 @@ describe("db_schema:", () => {
       expect(callback).toHaveBeenCalledOnceWith({
         name: "interest group name 1",
         trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
-        ads: [{ renderingUrl: "about:blank#1", metadata: { price: 0.01 } }],
+        ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
     });
 

--- a/frame/handler_test.ts
+++ b/frame/handler_test.ts
@@ -56,8 +56,8 @@ describe("handleRequest", () => {
 
   const name = "interest group name";
   const trustedBiddingSignalsUrl = "https://trusted-server.test/bidding";
-  const renderingUrl = "about:blank";
-  const ads = [{ renderingUrl, metadata: { price: 0.02 } }];
+  const renderUrl = "about:blank";
+  const ads = [{ renderUrl, metadata: { price: 0.02 } }];
   const group = { name, trustedBiddingSignalsUrl, ads };
   const joinMessageEvent = new MessageEvent("message", {
     data: messageDataFromRequest({
@@ -144,7 +144,7 @@ describe("handleRequest", () => {
     const { data } = event;
     assertToSatisfyTypeGuard(data, isRunAdAuctionResponse);
     assertToBeString(data);
-    expect(sessionStorage.getItem(data)).toBe(renderingUrl);
+    expect(sessionStorage.getItem(data)).toBe(renderUrl);
     expect(fakeServerHandler).toHaveBeenCalledTimes(2);
     expect(fakeServerHandler).toHaveBeenCalledWith(
       jasmine.objectContaining<FakeRequest>({

--- a/frame/main.ts
+++ b/frame/main.ts
@@ -44,12 +44,12 @@ function connect(targetWindow: Window, targetOrigin: string) {
 
 function render(doc: Document, fragment: string) {
   const token = fragment.substring(1);
-  const renderingUrl = sessionStorage.getItem(token);
-  if (!renderingUrl) {
+  const renderUrl = sessionStorage.getItem(token);
+  if (!renderUrl) {
     throw new Error(`Invalid token: ${token}`);
   }
   const iframe = doc.createElement("iframe");
-  iframe.src = renderingUrl;
+  iframe.src = renderUrl;
   iframe.scrolling = "no";
   iframe.style.border = "none";
   iframe.style.width =

--- a/frame/main_test.ts
+++ b/frame/main_test.ts
@@ -28,7 +28,7 @@ describe("main", () => {
   cleanDomAfterEach();
   clearStorageBeforeAndAfter();
 
-  const renderingUrl = "about:blank#ad";
+  const renderUrl = "about:blank#ad";
 
   it("should connect to parent window and handle requests from it", async () => {
     const iframe = document.createElement("iframe");
@@ -46,7 +46,7 @@ describe("main", () => {
         kind: RequestKind.JOIN_AD_INTEREST_GROUP,
         group: {
           name: "interest group name",
-          ads: [{ renderingUrl, metadata: { price: 0.02 } }],
+          ads: [{ renderUrl, metadata: { price: 0.02 } }],
         },
       })
     );
@@ -61,13 +61,13 @@ describe("main", () => {
     const { data: auctionResponse } = auctionMessageEvent;
     assertToSatisfyTypeGuard(auctionResponse, isRunAdAuctionResponse);
     assertToBeString(auctionResponse);
-    expect(sessionStorage.getItem(auctionResponse)).toBe(renderingUrl);
+    expect(sessionStorage.getItem(auctionResponse)).toBe(renderUrl);
   });
 
   const token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
   it("should render an ad", () => {
-    sessionStorage.setItem(token, renderingUrl);
+    sessionStorage.setItem(token, renderUrl);
     const outerIframe = document.createElement("iframe");
     outerIframe.src = "about:blank#" + token;
     document.body.appendChild(outerIframe);
@@ -76,11 +76,11 @@ describe("main", () => {
     const innerIframe =
       outerIframe.contentWindow.document.querySelector("iframe");
     assertToBeTruthy(innerIframe);
-    expect(innerIframe.src).toBe(renderingUrl);
+    expect(innerIframe.src).toBe(renderUrl);
   });
 
   it("should render with the exact same dimensions as the outer iframe, with no borders or scrollbars", async () => {
-    sessionStorage.setItem(token, renderingUrl);
+    sessionStorage.setItem(token, renderUrl);
     const outerIframe = document.createElement("iframe");
     outerIframe.src = "about:blank#" + token;
     outerIframe.style.width = "123px";

--- a/lib/public_api.ts
+++ b/lib/public_api.ts
@@ -10,7 +10,11 @@
  */
 
 import { awaitConnectionFromIframe } from "./connection";
-import { Ad, AuctionAdConfig, InterestGroup } from "./shared/api_types";
+import {
+  AuctionAd,
+  AuctionAdConfig,
+  AuctionAdInterestGroup,
+} from "./shared/api_types";
 import { awaitMessageToPort } from "./shared/messaging";
 import {
   isRunAdAuctionResponse,
@@ -19,7 +23,7 @@ import {
 } from "./shared/protocol";
 
 export { VERSION } from "./shared/version";
-export { Ad, AuctionAdConfig, InterestGroup };
+export { AuctionAd, AuctionAdConfig, AuctionAdInterestGroup };
 
 /**
  * A class whose instance methods correspond to the APIs exposed by FLEDGE.
@@ -140,7 +144,7 @@ export class FledgeShim {
    * @see {@link InterestGroup} for further behavioral notes.
    * @see https://github.com/WICG/turtledove/blob/main/FLEDGE.md#11-joining-interest-groups
    */
-  joinAdInterestGroup(group: InterestGroup): void {
+  joinAdInterestGroup(group: AuctionAdInterestGroup): void {
     const messageData = messageDataFromRequest({
       kind: RequestKind.JOIN_AD_INTEREST_GROUP,
       group: {
@@ -168,7 +172,7 @@ export class FledgeShim {
    * @see {@link InterestGroup} for behavioral notes.
    * @see https://github.com/WICG/turtledove/blob/main/FLEDGE.md#11-joining-interest-groups
    */
-  leaveAdInterestGroup(group: InterestGroup): void {
+  leaveAdInterestGroup(group: AuctionAdInterestGroup): void {
     const messageData = messageDataFromRequest({
       kind: RequestKind.LEAVE_AD_INTEREST_GROUP,
       group,

--- a/lib/public_api_test.ts
+++ b/lib/public_api_test.ts
@@ -11,7 +11,7 @@ import {
   FakeServerHandler,
   setFakeServerHandler,
 } from "../testing/http";
-import { create, renderingUrlFromAuctionResult } from "../testing/public_api";
+import { create, renderUrlFromAuctionResult } from "../testing/public_api";
 import { clearStorageBeforeAndAfter } from "../testing/storage";
 import { FledgeShim } from "./public_api";
 
@@ -61,45 +61,45 @@ describe("FledgeShim", () => {
 
     it("should return a single ad", async () => {
       const fledgeShim = create();
-      const renderingUrl = "about:blank";
+      const renderUrl = "about:blank";
       fledgeShim.joinAdInterestGroup({
         name,
-        ads: [{ renderingUrl, metadata: { price: 0.02 } }],
+        ads: [{ renderUrl, metadata: { price: 0.02 } }],
       });
       const token = await fledgeShim.runAdAuction({});
       assertToBeTruthy(token);
-      expect(await renderingUrlFromAuctionResult(token)).toBe(renderingUrl);
+      expect(await renderUrlFromAuctionResult(token)).toBe(renderUrl);
     });
 
     it("should return the higher-priced ad from a single interest group", async () => {
       const fledgeShim = create();
-      const renderingUrl = "about:blank#1";
+      const renderUrl = "about:blank#1";
       fledgeShim.joinAdInterestGroup({
         name,
         ads: [
-          { renderingUrl: "about:blank#2", metadata: { price: 0.01 } },
-          { renderingUrl, metadata: { price: 0.02 } },
+          { renderUrl: "about:blank#2", metadata: { price: 0.01 } },
+          { renderUrl, metadata: { price: 0.02 } },
         ],
       });
       const token = await fledgeShim.runAdAuction({});
       assertToBeTruthy(token);
-      expect(await renderingUrlFromAuctionResult(token)).toBe(renderingUrl);
+      expect(await renderUrlFromAuctionResult(token)).toBe(renderUrl);
     });
 
     it("should return the higher-priced ad across multiple interest groups", async () => {
       const fledgeShim = create();
-      const renderingUrl = "about:blank#1";
+      const renderUrl = "about:blank#1";
       fledgeShim.joinAdInterestGroup({
         name: "interest group 1",
-        ads: [{ renderingUrl: "about:blank#2", metadata: { price: 0.01 } }],
+        ads: [{ renderUrl: "about:blank#2", metadata: { price: 0.01 } }],
       });
       fledgeShim.joinAdInterestGroup({
         name: "interest group 2",
-        ads: [{ renderingUrl, metadata: { price: 0.02 } }],
+        ads: [{ renderUrl, metadata: { price: 0.02 } }],
       });
       const token = await fledgeShim.runAdAuction({});
       assertToBeTruthy(token);
-      expect(await renderingUrlFromAuctionResult(token)).toBe(renderingUrl);
+      expect(await renderUrlFromAuctionResult(token)).toBe(renderUrl);
     });
 
     const trustedBiddingSignalsUrl = "https://trusted-server.test/bidding";
@@ -110,7 +110,7 @@ describe("FledgeShim", () => {
       fledgeShim.joinAdInterestGroup({
         name: "interest group 1",
         trustedBiddingSignalsUrl,
-        ads: [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }],
+        ads: [{ renderUrl: "about:blank", metadata: { price: 0.02 } }],
       });
       const fakeServerHandler = jasmine
         .createSpy<FakeServerHandler>()
@@ -171,10 +171,10 @@ describe("FledgeShim", () => {
   describe("joinAdInterestGroup", () => {
     it("should overwrite old property values with new ones", async () => {
       const fledgeShim = create();
-      const renderingUrl = "about:blank";
+      const renderUrl = "about:blank";
       fledgeShim.joinAdInterestGroup({
         name,
-        ads: [{ renderingUrl, metadata: { price: 0.02 } }],
+        ads: [{ renderUrl, metadata: { price: 0.02 } }],
       });
       fledgeShim.joinAdInterestGroup({
         name,
@@ -185,10 +185,10 @@ describe("FledgeShim", () => {
 
     it("should not overwrite old property values with undefined ones", async () => {
       const fledgeShim = create();
-      const renderingUrl = "about:blank";
+      const renderUrl = "about:blank";
       fledgeShim.joinAdInterestGroup({
         name,
-        ads: [{ renderingUrl, metadata: { price: 0.02 } }],
+        ads: [{ renderUrl, metadata: { price: 0.02 } }],
       });
       fledgeShim.joinAdInterestGroup({
         name,
@@ -196,7 +196,7 @@ describe("FledgeShim", () => {
       });
       const token = await fledgeShim.runAdAuction({});
       assertToBeTruthy(token);
-      expect(await renderingUrlFromAuctionResult(token)).toBe(renderingUrl);
+      expect(await renderUrlFromAuctionResult(token)).toBe(renderUrl);
     });
   });
 
@@ -205,7 +205,7 @@ describe("FledgeShim", () => {
       const fledgeShim = create();
       fledgeShim.joinAdInterestGroup({
         name,
-        ads: [{ renderingUrl: "about:blank", metadata: { price: 0.02 } }],
+        ads: [{ renderUrl: "about:blank", metadata: { price: 0.02 } }],
       });
       fledgeShim.leaveAdInterestGroup({ name });
       expect(await fledgeShim.runAdAuction({})).toBeNull();

--- a/lib/shared/api_types.ts
+++ b/lib/shared/api_types.ts
@@ -17,12 +17,12 @@
  * present; they are our best guess as to how this will work, and may be
  * replaced later with a different API.
  */
-export interface Ad {
+export interface AuctionAd {
   /**
    * The URL where the actual creative is hosted. This will be used as the `src`
    * of an iframe that will appear on the page if this ad wins.
    */
-  renderingUrl: string;
+  renderUrl: string;
   /** Additional metadata about this ad that can be read by the auction. */
   metadata: {
     /**
@@ -52,7 +52,7 @@ export interface Ad {
  *
  * @see https://github.com/WICG/turtledove/blob/main/FLEDGE.md#1-browsers-record-interest-groups
  */
-export interface InterestGroup {
+export interface AuctionAdInterestGroup {
   /**
    * A name that uniquely identifies this interest group within the browser,
    * that can be used to refer to it in order to update or delete it later.
@@ -67,7 +67,7 @@ export interface InterestGroup {
    * Ads to be entered into the auction for impressions that this interest group
    * is permitted to bid on.
    */
-  ads?: Ad[];
+  ads?: AuctionAd[];
 }
 
 /**

--- a/lib/shared/protocol.ts
+++ b/lib/shared/protocol.ts
@@ -10,7 +10,7 @@
  * the initial handshake. For simple data types, type guards are used instead.
  */
 
-import { AuctionAdConfig, InterestGroup } from "../public_api";
+import { AuctionAdConfig, AuctionAdInterestGroup } from "../public_api";
 import { isArray } from "./guards";
 
 /**
@@ -20,8 +20,8 @@ import { isArray } from "./guards";
  * for that API.
  */
 export type FledgeRequest =
-  | { kind: RequestKind.JOIN_AD_INTEREST_GROUP; group: InterestGroup }
-  | { kind: RequestKind.LEAVE_AD_INTEREST_GROUP; group: InterestGroup }
+  | { kind: RequestKind.JOIN_AD_INTEREST_GROUP; group: AuctionAdInterestGroup }
+  | { kind: RequestKind.LEAVE_AD_INTEREST_GROUP; group: AuctionAdInterestGroup }
   | { kind: RequestKind.RUN_AD_AUCTION; config: AuctionAdConfig };
 
 /**
@@ -67,13 +67,11 @@ export function requestFromMessageData(
           if (!(isArray(adMessageData) && adMessageData.length === 2)) {
             return null;
           }
-          const [renderingUrl, price] = adMessageData;
-          if (
-            !(typeof renderingUrl === "string" && typeof price === "number")
-          ) {
+          const [renderUrl, price] = adMessageData;
+          if (!(typeof renderUrl === "string" && typeof price === "number")) {
             return null;
           }
-          ads.push({ renderingUrl, metadata: { price } });
+          ads.push({ renderUrl, metadata: { price } });
         }
       } else if (adsMessageData !== undefined) {
         return null;
@@ -122,8 +120,8 @@ export function messageDataFromRequest(request: FledgeRequest): unknown {
         kind,
         name,
         trustedBiddingSignalsUrl,
-        ads?.map(({ renderingUrl, metadata: { price } }) => [
-          renderingUrl,
+        ads?.map(({ renderUrl: renderUrl, metadata: { price } }) => [
+          renderUrl,
           price,
         ]),
       ];

--- a/lib/shared/protocol_test.ts
+++ b/lib/shared/protocol_test.ts
@@ -28,8 +28,8 @@ const requests: Array<{ request: FledgeRequest; messageData: unknown }> = [
         name: "interest group name",
         trustedBiddingSignalsUrl: "https://trusted-server.example/bidding",
         ads: [
-          { renderingUrl: "https://ad.example/1", metadata: { price: 0.02 } },
-          { renderingUrl: "https://ad.example/2", metadata: { price: 0.04 } },
+          { renderUrl: "https://ad.example/1", metadata: { price: 0.02 } },
+          { renderUrl: "https://ad.example/2", metadata: { price: 0.04 } },
         ],
       },
     },
@@ -200,8 +200,8 @@ describe("messageDataFromRequest", () => {
           name: "interest group name",
           trustedBiddingSignalsUrl: "https://trusted-server.example/bidding",
           ads: [
-            { renderingUrl: "https://ad.example/1", metadata: { price: 0.02 } },
-            { renderingUrl: "https://ad.example/2", metadata: { price: 0.04 } },
+            { renderUrl: "https://ad.example/1", metadata: { price: 0.02 } },
+            { renderUrl: "https://ad.example/2", metadata: { price: 0.04 } },
           ],
         },
       })

--- a/testing/public_api.ts
+++ b/testing/public_api.ts
@@ -35,13 +35,13 @@ afterEach(() => {
 });
 
 /**
- * Given a string returned from `runAdAuction`, returns the `renderingUrl` of
- * the winning ad. Note that this is only possible because the frame served by
- * Karma is same-origin to the page where the tests run; browser-native
+ * Given a string returned from `runAdAuction`, returns the `renderUrl` of the
+ * winning ad. Note that this is only possible because the frame served by Karma
+ * is same-origin to the page where the tests run; browser-native
  * implementations will not allow this, nor is it possible in production with
  * the shim when using a frame on a different origin from the publisher page.
  */
-export async function renderingUrlFromAuctionResult(
+export async function renderUrlFromAuctionResult(
   auctionResultUrl: string
 ): Promise<string> {
   const outerIframe = document.createElement("iframe");

--- a/testing/public_api_test.ts
+++ b/testing/public_api_test.ts
@@ -7,7 +7,7 @@
 import "jasmine";
 import { FledgeShim } from "../lib/public_api";
 import { assertToBeInstanceOf } from "./assert";
-import { create, renderingUrlFromAuctionResult } from "./public_api";
+import { create, renderUrlFromAuctionResult } from "./public_api";
 import { clearStorageBeforeAndAfter } from "./storage";
 
 describe("create", () => {
@@ -26,24 +26,24 @@ describe("create", () => {
   });
 });
 
-describe("renderingUrlFromAuctionResult", () => {
+describe("renderUrlFromAuctionResult", () => {
   clearStorageBeforeAndAfter();
 
   const token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  const renderingUrl = "about:blank#ad";
+  const renderUrl = "about:blank#ad";
 
   it("should return the rendering URL from an auction result", async () => {
-    sessionStorage.setItem(token, renderingUrl);
-    expect(await renderingUrlFromAuctionResult("/frame.html#" + token)).toBe(
-      renderingUrl
+    sessionStorage.setItem(token, renderUrl);
+    expect(await renderUrlFromAuctionResult("/frame.html#" + token)).toBe(
+      renderUrl
     );
   });
 
   it("should clean up after itself", async () => {
-    sessionStorage.setItem(token, renderingUrl);
+    sessionStorage.setItem(token, renderUrl);
     const existingDom = document.documentElement.cloneNode(/* deep= */ true);
     assertToBeInstanceOf(existingDom, HTMLHtmlElement);
-    await renderingUrlFromAuctionResult("/frame.html#" + token);
+    await renderUrlFromAuctionResult("/frame.html#" + token);
     expect(document.documentElement).toEqual(existingDom);
   });
 });


### PR DESCRIPTION
Ad is now AuctionAd.
renderingUrl is now renderUrl.
InterestGroup is now AuctionAdInterestGroup.