### PR TITLE
s/spec/explainer/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FLEDGE Shim
 
 We're building a pure-JavaScript implementation of the
-[FLEDGE spec](https://github.com/WICG/turtledove/blob/master/FLEDGE.md), on top
-of existing browser APIs. The goal is to allow testing as much of FLEDGE as
+[FLEDGE proposal](https://github.com/WICG/turtledove/blob/master/FLEDGE.md), on
+top of existing browser APIs. The goal is to allow testing as much of FLEDGE as
 possible, in as realistic a manner as possible, given the constraint of not
 being able to add new features to the browser itself.
 
@@ -33,7 +33,7 @@ translates the API from functions to messages.
 ## API
 
 We're planning to implement the API as closely as possible to what is presented
-in the spec, but some aspects necessarily differ due to the constraints of
+in the explainer, but some aspects necessarily differ due to the constraints of
 running on publisher and advertiser pages, and implementing without browser
 changes.
 
@@ -109,14 +109,14 @@ same page that called `runAdAuction`.
 
 #### Buyer and Seller Logic
 
-The spec allows buyers and sellers to provide custom JavaScript (`generate_bid`,
-`score_ad`) which will have access to interest group information. That access is
-compatible with the privacy model, because these worklets are heavily locked
-down, have no network access, and operate as pure functions. We are not aware of
-any secure way to execute arbitrary JavaScript while protecting information from
-exfiltration. Initially, we are planning to require buyers and sellers to check
-their logic into this repo. Later, we may be able to use Web Assembly or
-something custom to avoid that requirement.
+The proposal allows buyers and sellers to provide custom JavaScript
+(`generate_bid`, `score_ad`) which will have access to interest group
+information. That access is compatible with the privacy model, because these
+worklets are heavily locked down, have no network access, and operate as pure
+functions. We are not aware of any secure way to execute arbitrary JavaScript
+while protecting information from exfiltration. Initially, we are planning to
+require buyers and sellers to check their logic into this repo. Later, we may be
+able to use Web Assembly or something custom to avoid that requirement.
 
 Users may wish to test FLEDGE in circumstances where the privacy guarantees are
 not necessary, such as internal end-to-end testing. We will probably build

--- a/frame/fetch.ts
+++ b/frame/fetch.ts
@@ -31,8 +31,8 @@ export enum FetchJsonStatus {
   NETWORK_ERROR,
   /**
    * An HTTP response was received and exposed to the script, but didn't conform
-   * to all the preconditions (some of which aren't currently in the spec but
-   * are enforced by Chrome's implementation).
+   * to all the preconditions (some of which aren't currently in the explainer
+   * but are enforced by Chrome's implementation).
    */
   VALIDATION_ERROR,
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fledge-shim",
   "version": "0.1.0",
-  "description": "A pure-JavaScript implementation of the FLEDGE spec.",
+  "description": "A pure-JavaScript implementation of the FLEDGE proposal.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/google/fledge-shim.git"

--- a/lib/public_api.ts
+++ b/lib/public_api.ts
@@ -134,7 +134,7 @@ export class FledgeShim {
    * `trustedBiddingSignalsUrl` of an existing interest group with `undefined`
    * without deleting the entire interest group.
    *
-   * The second parameter from the FLEDGE spec (`duration`) is not yet
+   * The second parameter from the FLEDGE explainer (`duration`) is not yet
    * supported.
    *
    * @see {@link InterestGroup} for further behavioral notes.

--- a/lib/shared/api_types.ts
+++ b/lib/shared/api_types.ts
@@ -13,8 +13,8 @@
  * An ad creative that can participate in an auction and later be rendered onto
  * the page if it wins.
  *
- * The properties of this type aren't actually specified in the FLEDGE spec at
- * present; they are our best guess as to how this will work, and may be
+ * The properties of this type aren't actually specified in the FLEDGE explainer
+ * at present; they are our best guess as to how this will work, and may be
  * replaced later with a different API.
  */
 export interface Ad {


### PR DESCRIPTION
https://github.com/WICG/turtledove/blob/main/FLEDGE.md is an "explainer". There is no FLEDGE spec at present.

"Proposal" is now used when referring to the actual feature rather than to a document that says what it does.