### PR TITLE
Add missing cleanDomAfterEach call to test

### DIFF
--- a/testing/messaging_test.ts
+++ b/testing/messaging_test.ts
@@ -77,6 +77,8 @@ describe("testing/messaging:", () => {
   });
 
   describe("iframeSendingPostMessageErrorToParent", () => {
+    cleanDomAfterEach();
+
     it("should cause a deserialization failure on the current window", async () => {
       addEventListener("message", fail);
       try {


### PR DESCRIPTION
This was causing the test to flake. Oops.