### PR TITLE
Always close all ports as soon as possible

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -80,7 +80,12 @@ export async function awaitRunAdAuctionResponseToPort(
   if (!event) {
     throw new Error(DESERIALIZATION_ERROR_MESSAGE);
   }
-  const { data } = event;
+  const { data, ports } = event;
+  // Normally there shouldn't be any ports here, but in case a bogus frame sent
+  // some, we close them to avoid memory leaks.
+  for (const port of ports) {
+    port.close();
+  }
   if (!isRunAdAuctionResponse(data)) {
     const error: Partial<ErrorWithData> = new Error(
       "Malformed response: Expected RunAdAuctionResponse"

--- a/lib/connection_test.ts
+++ b/lib/connection_test.ts
@@ -120,7 +120,7 @@ describe("awaitRunAdAuctionResponseToPort", () => {
     const { port1: receiver, port2: sender } = new MessageChannel();
     const tokenPromise = awaitRunAdAuctionResponseToPort(receiver);
     const payload = new Date();
-    sender.postMessage(payload);
+    sender.postMessage(payload, [new MessageChannel().port1]);
     const error = await tokenPromise.then(fail, (error: unknown) => error);
     assertToBeInstanceOf(error, Error);
     const errorWithData: Partial<ErrorWithData> = error;

--- a/lib/shared/messaging.ts
+++ b/lib/shared/messaging.ts
@@ -28,14 +28,18 @@ export function awaitMessageFromSelfToSelf(): Promise<MessageEvent<unknown> | nu
 /**
  * Returns a promise that resolves to the first `MessageEvent` sent to `port`,
  * which is activated if it hasn't been already, or to null if a deserialization
- * error occurs.
+ * error occurs. Closes the port afterwards.
  */
-export function awaitMessageToPort(
+export async function awaitMessageToPort(
   port: MessagePort
 ): Promise<MessageEvent<unknown> | null> {
-  const messageEventPromise = awaitMessage(port, () => true);
-  port.start();
-  return messageEventPromise;
+  try {
+    const messageEventPromise = awaitMessage(port, () => true);
+    port.start();
+    return await messageEventPromise;
+  } finally {
+    port.close();
+  }
 }
 
 function awaitMessage(

--- a/lib/shared/messaging_test.ts
+++ b/lib/shared/messaging_test.ts
@@ -121,5 +121,13 @@ describe("messaging:", () => {
         await awaitMessageToPort(await portReceivingMessageError())
       ).toBeNull();
     });
+
+    it("should close the port", async () => {
+      const { port1: receiver, port2: sender } = new MessageChannel();
+      const messageEventPromise = awaitMessageToPort(receiver);
+      sender.postMessage(null);
+      await messageEventPromise;
+      await expectAsync(receiver).not.toBeEntangledWith(sender);
+    });
   });
 });


### PR DESCRIPTION
Cross-process reference cycle detection can be expensive, so to avoid memory leaks, we explicitly deinitialize ports so that they can be collected purely locally.