### PR TITLE
Fix coverage reporting

### DIFF
--- a/frame/auction.ts
+++ b/frame/auction.ts
@@ -99,12 +99,13 @@ async function fetchAndValidateTrustedSignals(
   try {
     url = new URL(baseUrl);
   } catch (error: unknown) {
+    /* istanbul ignore else */
     if (error instanceof TypeError) {
       logWarning("Invalid URL:", [baseUrl]);
       return;
+    } else {
+      throw error;
     }
-    /* istanbul ignore next */
-    throw error;
   }
   if (url.search) {
     logWarning("Query string not allowed in URL:", [baseUrl]);

--- a/frame/fetch.ts
+++ b/frame/fetch.ts
@@ -67,11 +67,12 @@ export async function tryFetchJson(url: string): Promise<FetchJsonResult> {
   try {
     response = await fetch(url, requestInit);
   } catch (error: unknown) {
+    /* istanbul ignore else */
     if (error instanceof TypeError) {
       return { status: FetchJsonStatus.NETWORK_ERROR };
+    } else {
+      throw error;
     }
-    /* istanbul ignore next */
-    throw error;
   }
   const contentType = response.headers.get("Content-Type");
   if (contentType === null) {
@@ -107,15 +108,14 @@ export async function tryFetchJson(url: string): Promise<FetchJsonResult> {
   } catch (error: unknown) {
     if (error instanceof TypeError) {
       return { status: FetchJsonStatus.NETWORK_ERROR };
-    }
-    if (error instanceof SyntaxError) {
+    } /* istanbul ignore else */ else if (error instanceof SyntaxError) {
       return {
         status: FetchJsonStatus.VALIDATION_ERROR,
         errorMessage: error.message,
       };
+    } else {
+      throw error;
     }
-    /* istanbul ignore next */
-    throw error;
   }
   return { status: FetchJsonStatus.OK, value };
 }

--- a/frame/indexeddb.ts
+++ b/frame/indexeddb.ts
@@ -32,10 +32,9 @@ const dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
   dbRequest.onerror = () => {
     reject(dbRequest.error);
   };
-  dbRequest.onblocked = () => {
-    // Since the version number is 1 (the lowest allowed), it shouldn't be
-    // possible for an earlier version of the same database to already be open.
-    /* istanbul ignore next */
+  // Since the version number is 1 (the lowest allowed), it shouldn't be
+  // possible for an earlier version of the same database to already be open.
+  dbRequest.onblocked = /* istanbul ignore next */ () => {
     reject(new Error());
   };
 });
@@ -68,13 +67,14 @@ export async function useStore(
       // on potentially expensive writes to disk.
       tx = db.transaction(storeName, txMode, { durability: "relaxed" });
     } catch (error: unknown) {
+      /* istanbul ignore else */
       if (error instanceof DOMException && error.name === "NotFoundError") {
         logError(error.message);
         resolve(false);
         return;
+      } else {
+        throw error;
       }
-      /* istanbul ignore next */
-      throw error;
     }
     tx.oncomplete = () => {
       resolve(true);

--- a/lib/public_api.ts
+++ b/lib/public_api.ts
@@ -244,11 +244,12 @@ function absoluteUrl(url: string) {
   try {
     return new URL(url, document.baseURI);
   } catch (error: unknown) {
+    /* istanbul ignore else */
     if (error instanceof TypeError) {
       throw new Error("Invalid URL: " + url);
+    } else {
+      throw error;
     }
-    /* istanbul ignore next */
-    throw error;
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "exclude": ["dist/"],
   "compilerOptions": {
     "importHelpers": true,
+    "sourceMap": true,
     "target": "ES2020",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Coverage reporting was all screwed up and I couldn't figure out why, until it turned out that I simply didn't have source maps turned on in TypeScript.

This also revealed that some of my istanbul ignore comments weren't quite right, so fix them.