### PR TITLE
Introduce bidding worklets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,7 @@ jobs:
       - run: npm ci
       - run: npm run check-format
       - run: npm run build
+        env:
+          ALLOWED_LOGIC_URL_PREFIXES:
       - run: npm run lint
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -11,6 +11,31 @@ being able to add new features to the browser itself.
 This project has not yet been tested in production; use at your own risk.
 Furthermore, most of the API is not yet implemented.
 
+## Building
+
+As with most JavaScript projects, you'll need Node.js and npm. Install
+dependencies with `npm install` as per usual.
+
+In order to build the frame, you have to set a list of allowed URL prefixes for
+the worklets. The frame will only allow `biddingLogicUrl` and `decisionLogicUrl`
+values that start with those prefixes. Each such prefix must consist of an HTTPS
+origin optionally followed by a path, and must end with a slash. So, for
+instance, you could allow worklet scripts under `https://dsp.example`, or
+`https://ssp.example/js/`.
+
+The reason for this is because worklet scripts have access to cross-site
+interest group and related data, and nothing prevents them from exfiltrating
+that data. So, if you're going to host the frame and have such cross-site data
+stored in its origin in users' browsers, you should make sure to only allow
+worklet scripts from sources that you trust not to do that.
+
+Once you have an allowlist, set the `ALLOWED_LOGIC_URL_PREFIXES` environment
+variable to the allowlist with the entries separated by commas, then run
+`npm run build`. For example, on Mac or Linux, you might run
+`ALLOWED_LOGIC_URL_PREFIXES=https://dsp.example/,https://ssp.example/js/ npm run build`;
+on Windows PowerShell, the equivalent would be
+`$Env:ALLOWED_LOGIC_URL_PREFIXES = "https://dsp.example/,https://ssp.example/js/"; npm run build`.
+
 ## Design
 
 FLEDGE requires a way to store information in the browser that is (a) accessible

--- a/fake_server.js
+++ b/fake_server.js
@@ -40,9 +40,14 @@ onfetch = async (fetchEvent) => {
   }
   const { port1: receiver, port2: sender } = new MessageChannel();
   fetchEvent.respondWith(
-    new Promise((resolve) => {
-      receiver.onmessage = ({ data: [status, statusText, headers, body] }) => {
+    new Promise((resolve, reject) => {
+      receiver.onmessage = ({ data }) => {
         receiver.close();
+        if (!data) {
+          reject();
+          return;
+        }
+        let [status, statusText, headers, body] = data;
         if (body === null) {
           // Cause any attempt to read the body to reject.
           body = new ReadableStream({

--- a/frame/auction_test.ts
+++ b/frame/auction_test.ts
@@ -19,71 +19,488 @@ describe("runAdAuction", () => {
   clearStorageBeforeAndAfter();
 
   const name = "interest group name";
+  const biddingLogicUrl1 = "https://dsp-1.test/bidder.js";
+  const biddingLogicUrl2 = "https://dsp-2.test/bidder.js";
+  const biddingLogicUrl3 = "https://dsp-3.test/bidder.js";
+  const biddingLogicUrl4 = "https://dsp-4.test/bidder.js";
+  const javaScriptHeaders = {
+    "Content-Type": "application/javascript",
+    "X-Allow-FLEDGE": "true",
+  };
   const ad1 = { renderUrl: "about:blank#1", metadata: { price: 0.01 } };
   const ad2 = { renderUrl: "about:blank#2", metadata: { price: 0.02 } };
   const ad3 = { renderUrl: "about:blank#3", metadata: { price: 0.03 } };
   const ad4 = { renderUrl: "about:blank#4", metadata: { price: 0.04 } };
   const hostname = "www.example.com";
+  const allowedLogicUrlPrefixes = [
+    "https://dsp-1.test/",
+    "https://dsp-2.test/",
+    "https://dsp-3.test/",
+    "https://dsp-4.test/",
+  ];
 
-  it("should return the higher-priced ad from a single interest group", async () => {
-    expect(await storeInterestGroup({ name, ads: [ad1, ad2] })).toBeTrue();
-    const token = await runAdAuction({}, hostname);
+  it("should return an ad from a single interest group", async () => {
+    const fakeServerHandler = jasmine
+      .createSpy<FakeServerHandler>("fakeServerHandler")
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid({",
+          "  name,",
+          "  biddingLogicUrl,",
+          "  trustedBiddingSignalsUrl,",
+          "  ads,",
+          "}) {",
+          "  if (",
+          "    !(",
+          "      name === 'interest group name' &&",
+          "      biddingLogicUrl === 'https://dsp-1.test/bidder.js' &&",
+          "      trustedBiddingSignalsUrl === undefined &&",
+          "      ads.length === 2 &&",
+          "      ads[0].renderUrl === 'about:blank#1' &&",
+          "      ads[0].metadata.price === 0.01 &&",
+          "      ads[1].renderUrl === 'about:blank#2' &&",
+          "      ads[1].metadata.price === 0.02",
+          "    )",
+          "  ) {",
+          "    throw new Error();",
+          "  }",
+          "  return { bid: 0.03, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+      });
+    setFakeServerHandler(fakeServerHandler);
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1, ad2],
+      })
+    ).toBeTrue();
+    const token = await runAdAuction({}, hostname, allowedLogicUrlPrefixes);
     assertToBeString(token);
     expect(sessionStorage.getItem(token)).toBe(ad2.renderUrl);
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith({
+      url: new URL(biddingLogicUrl1),
+      method: "GET",
+      headers: jasmine.objectContaining<{ [name: string]: string }>({
+        "accept": "application/javascript",
+      }),
+      body: Uint8Array.of(),
+      hasCredentials: false,
+    });
   });
 
   it("should return the higher-priced ad across multiple interest groups", async () => {
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl1),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid({",
+          "  name,",
+          "  biddingLogicUrl,",
+          "  trustedBiddingSignalsUrl,",
+          "  ads,",
+          "}) {",
+          "  if (",
+          "    !(",
+          "      name === 'interest group name 1' &&",
+          "      biddingLogicUrl === 'https://dsp-1.test/bidder.js' &&",
+          "      trustedBiddingSignalsUrl === undefined &&",
+          "      ads.length === 1 &&",
+          "      ads[0].renderUrl === 'about:blank#1' &&",
+          "      ads[0].metadata.price === 0.01",
+          "    )",
+          "  ) {",
+          "    throw new Error();",
+          "  }",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl2),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid({",
+          "  name,",
+          "  biddingLogicUrl,",
+          "  trustedBiddingSignalsUrl,",
+          "  ads,",
+          "}) {",
+          "  if (",
+          "    !(",
+          "      name === 'interest group name 2' &&",
+          "      biddingLogicUrl === 'https://dsp-2.test/bidder.js' &&",
+          "      trustedBiddingSignalsUrl === undefined &&",
+          "      ads.length === 1 &&",
+          "      ads[0].renderUrl === 'about:blank#2' &&",
+          "      ads[0].metadata.price === 0.02",
+          "    )",
+          "  ) {",
+          "    throw new Error();",
+          "  }",
+          "  return { bid: 0.04, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+      });
+    setFakeServerHandler(fakeServerHandler);
     expect(
-      await storeInterestGroup({ name: "interest group name 1", ads: [ad1] })
+      await storeInterestGroup({
+        name: "interest group name 1",
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
     ).toBeTrue();
     expect(
-      await storeInterestGroup({ name: "interest group name 2", ads: [ad2] })
+      await storeInterestGroup({
+        name: "interest group name 2",
+        biddingLogicUrl: biddingLogicUrl2,
+        ads: [ad2],
+      })
     ).toBeTrue();
-    const token = await runAdAuction({}, hostname);
+    const token = await runAdAuction({}, hostname, allowedLogicUrlPrefixes);
     assertToBeString(token);
     expect(sessionStorage.getItem(token)).toBe(ad2.renderUrl);
+    expect(fakeServerHandler).toHaveBeenCalledTimes(2);
+    expect(fakeServerHandler).toHaveBeenCalledWith({
+      url: new URL(biddingLogicUrl1),
+      method: "GET",
+      headers: jasmine.objectContaining<{ [name: string]: string }>({
+        "accept": "application/javascript",
+      }),
+      body: Uint8Array.of(),
+      hasCredentials: false,
+    });
+    expect(fakeServerHandler).toHaveBeenCalledWith({
+      url: new URL(biddingLogicUrl2),
+      method: "GET",
+      headers: jasmine.objectContaining<{ [name: string]: string }>({
+        "accept": "application/javascript",
+      }),
+      body: Uint8Array.of(),
+      hasCredentials: false,
+    });
   });
 
   it("should return true if there are no ads", async () => {
-    const result = await runAdAuction({}, hostname);
+    const result = await runAdAuction({}, hostname, allowedLogicUrlPrefixes);
     expect(result).toBeTrue();
     expect(sessionStorage.length).toBe(0);
   });
 
   it("should return tokens in the expected format", async () => {
-    expect(await storeInterestGroup({ name, ads: [ad1] })).toBeTrue();
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      })
+    );
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
+    ).toBeTrue();
     for (let i = 0; i < 100; i++) {
-      expect(await runAdAuction({}, hostname)).toMatch(/^[0-9a-f]{32}$/);
+      expect(await runAdAuction({}, hostname, allowedLogicUrlPrefixes)).toMatch(
+        /^[0-9a-f]{32}$/
+      );
     }
+  });
+
+  it("should drop bids that are zero", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      })
+    );
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTrue();
+  });
+
+  it("should drop bids that are negative", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: -0.02, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      })
+    );
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTrue();
+  });
+
+  it("should drop bids that are infinite", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: Infinity, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      })
+    );
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTrue();
+  });
+
+  it("should drop bids that are NaN", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: NaN, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      })
+    );
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTrue();
+  });
+
+  it("should drop bids on network error for bidding script", async () => {
+    setFakeServerHandler(() => Promise.resolve(null));
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTrue();
+  });
+
+  it("should drop bids on worklet error", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: javaScriptHeaders,
+        body: "throw new Error();",
+      })
+    );
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction(
+        {},
+        hostname,
+        allowedLogicUrlPrefixes,
+        "console.warn = () => {};"
+      )
+    ).toBeTrue();
+  });
+
+  it("should log a warning and drop bids for ads not in the interest group", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.02, render: 'https://advertiser.test/nope' };",
+          "}",
+        ].join("\n"),
+      })
+    );
+    const consoleSpy = spyOnAllFunctions(console);
+    const group = {
+      name,
+      biddingLogicUrl: biddingLogicUrl1,
+      trustedBiddingSignalsUrl: undefined,
+      ads: [ad1],
+    };
+    expect(await storeInterestGroup(group)).toBeTrue();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTrue();
+    expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
+      "https://advertiser.test/nope",
+      jasmine.any(String),
+      group
+    );
+  });
+
+  it("should log a warning and drop bids if bidding logic URL is not allowlisted", async () => {
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    setFakeServerHandler(fakeServerHandler);
+    const consoleSpy = spyOnAllFunctions(console);
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: "https://untrusted.test/bidder.js",
+        ads: [ad1],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTrue();
+    expect(fakeServerHandler).not.toHaveBeenCalled();
+    expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
+      "https://untrusted.test/bidder.js"
+    );
+  });
+
+  it("should log a warning and drop bids on missing header for bidding script", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: { "Content-Type": "application/javascript" },
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      })
+    );
+    const consoleSpy = spyOnAllFunctions(console);
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTrue();
+    expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
+      biddingLogicUrl1,
+      jasmine.any(String)
+    );
   });
 
   const trustedBiddingSignalsUrl = "https://trusted-server.test/bidding";
   const trustedScoringSignalsUrl = "https://trusted-server.test/scoring";
-  const headers = {
+  const jsonHeaders = {
     "Content-Type": "application/json",
     "X-Allow-FLEDGE": "true",
   };
   const trustedSignalsResponse = {
-    headers,
+    headers: jsonHeaders,
     body: '{"a": 1, "b": [true, null]}',
   };
 
   it("should fetch trusted bidding and scoring signals for ads in a single interest group", async () => {
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl1),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(trustedBiddingSignalsUrl + "?hostname=www.example.com"),
+        })
+      )
+      .and.resolveTo(trustedSignalsResponse);
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(trustedScoringSignalsUrl + "?keys=about%3Ablank%232"),
+        })
+      )
+      .and.resolveTo(trustedSignalsResponse);
+    setFakeServerHandler(fakeServerHandler);
     expect(
       await storeInterestGroup({
         name,
+        biddingLogicUrl: biddingLogicUrl1,
         trustedBiddingSignalsUrl,
         ads: [ad1, ad2],
       })
     ).toBeTrue();
-    const fakeServerHandler = jasmine
-      .createSpy<FakeServerHandler>()
-      .and.resolveTo(trustedSignalsResponse);
-    setFakeServerHandler(fakeServerHandler);
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl }, hostname)
+      await runAdAuction(
+        { trustedScoringSignalsUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
-    expect(fakeServerHandler).toHaveBeenCalledTimes(2);
+    expect(fakeServerHandler).toHaveBeenCalledTimes(3);
+    expect(fakeServerHandler).toHaveBeenCalledWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(biddingLogicUrl1),
+      })
+    );
     expect(fakeServerHandler).toHaveBeenCalledWith(
       jasmine.objectContaining<FakeRequest>({
         url: new URL(trustedBiddingSignalsUrl + "?hostname=www.example.com"),
@@ -95,9 +512,7 @@ describe("runAdAuction", () => {
     );
     expect(fakeServerHandler).toHaveBeenCalledWith(
       jasmine.objectContaining<FakeRequest>({
-        url: new URL(
-          trustedScoringSignalsUrl + "?keys=about%3Ablank%231,about%3Ablank%232"
-        ),
+        url: new URL(trustedScoringSignalsUrl + "?keys=about%3Ablank%232"),
         headers: jasmine.objectContaining<{ [name: string]: string }>({
           "accept": "application/json",
         }),
@@ -107,9 +522,83 @@ describe("runAdAuction", () => {
   });
 
   it("should fetch trusted bidding and scoring signals for ads across multiple interest groups", async () => {
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl1),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl2),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.05, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl3),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.04, render: 'about:blank#4' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(
+            "https://trusted-server-1.test/bidding?hostname=www.example.com"
+          ),
+        })
+      )
+      .and.resolveTo(trustedSignalsResponse);
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(
+            "https://trusted-server-2.test/bidding?hostname=www.example.com"
+          ),
+        })
+      )
+      .and.resolveTo(trustedSignalsResponse);
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(
+            trustedScoringSignalsUrl +
+              "?keys=about%3Ablank%231,about%3Ablank%232,about%3Ablank%234"
+          ),
+        })
+      )
+      .and.resolveTo(trustedSignalsResponse);
+    setFakeServerHandler(fakeServerHandler);
     expect(
       await storeInterestGroup({
         name: "interest group 1",
+        biddingLogicUrl: biddingLogicUrl1,
         trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
         ads: [ad1],
       })
@@ -117,28 +606,50 @@ describe("runAdAuction", () => {
     expect(
       await storeInterestGroup({
         name: "interest group 2",
+        biddingLogicUrl: biddingLogicUrl2,
         trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
         ads: [ad2, ad3],
       })
     ).toBeTrue();
     expect(
-      await storeInterestGroup({ name: "interest group 3", ads: [ad4] })
+      await storeInterestGroup({
+        name: "interest group 3",
+        biddingLogicUrl: biddingLogicUrl3,
+        ads: [ad4],
+      })
     ).toBeTrue();
     expect(
       await storeInterestGroup({
         name: "interest group 4",
+        biddingLogicUrl: biddingLogicUrl4,
         trustedBiddingSignalsUrl: "https://trusted-server-3.test/bidding",
         ads: [],
       })
     ).toBeTrue();
-    const fakeServerHandler = jasmine
-      .createSpy<FakeServerHandler>()
-      .and.resolveTo(trustedSignalsResponse);
     setFakeServerHandler(fakeServerHandler);
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl }, hostname)
+      await runAdAuction(
+        { trustedScoringSignalsUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
-    expect(fakeServerHandler).toHaveBeenCalledTimes(3);
+    expect(fakeServerHandler).toHaveBeenCalledTimes(6);
+    expect(fakeServerHandler).toHaveBeenCalledWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(biddingLogicUrl1),
+      })
+    );
+    expect(fakeServerHandler).toHaveBeenCalledWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(biddingLogicUrl2),
+      })
+    );
+    expect(fakeServerHandler).toHaveBeenCalledWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(biddingLogicUrl3),
+      })
+    );
     expect(fakeServerHandler).toHaveBeenCalledWith(
       jasmine.objectContaining<FakeRequest>({
         url: new URL(
@@ -165,7 +676,7 @@ describe("runAdAuction", () => {
       jasmine.objectContaining<FakeRequest>({
         url: new URL(
           trustedScoringSignalsUrl +
-            "?keys=about%3Ablank%231,about%3Ablank%232,about%3Ablank%233,about%3Ablank%234"
+            "?keys=about%3Ablank%231,about%3Ablank%232,about%3Ablank%234"
         ),
         headers: jasmine.objectContaining<{ [name: string]: string }>({
           "accept": "application/json",
@@ -175,63 +686,120 @@ describe("runAdAuction", () => {
     );
   });
 
-  it("should not fetch trusted scoring signals if there are no interest groups", async () => {
+  it("should not fetch anything if there are no interest groups", async () => {
     const fakeServerHandler =
       jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
     setFakeServerHandler(fakeServerHandler);
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl }, hostname)
+      await runAdAuction(
+        { trustedScoringSignalsUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
     expect(fakeServerHandler).not.toHaveBeenCalled();
   });
 
-  it("should not fetch trusted scoring signals if there are no ads in the interest groups", async () => {
-    expect(
-      await storeInterestGroup({ name, trustedBiddingSignalsUrl, ads: [] })
-    ).toBeTrue();
-    const fakeServerHandler = jasmine
-      .createSpy<FakeServerHandler>()
-      .and.resolveTo(trustedSignalsResponse);
+  it("should not fetch anything if there are no ads in the interest groups", async () => {
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
     setFakeServerHandler(fakeServerHandler);
-    await runAdAuction({ trustedScoringSignalsUrl }, hostname);
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        trustedBiddingSignalsUrl,
+        ads: [],
+      })
+    ).toBeTrue();
+    await runAdAuction(
+      { trustedScoringSignalsUrl },
+      hostname,
+      allowedLogicUrlPrefixes
+    );
     expect(fakeServerHandler).not.toHaveBeenCalled();
   });
 
   it("should not fetch trusted scoring signals if no URL is provided", async () => {
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl1),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(trustedBiddingSignalsUrl + "?hostname=www.example.com"),
+        })
+      )
+      .and.resolveTo(trustedSignalsResponse);
+    setFakeServerHandler(fakeServerHandler);
     expect(
       await storeInterestGroup({
         name,
+        biddingLogicUrl: biddingLogicUrl1,
         trustedBiddingSignalsUrl,
         ads: [ad1, ad2],
       })
     ).toBeTrue();
-    const fakeServerHandler = jasmine
-      .createSpy<FakeServerHandler>()
-      .and.resolveTo(trustedSignalsResponse);
-    setFakeServerHandler(fakeServerHandler);
-    expect(await runAdAuction({}, hostname)).toBeTruthy();
-    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTruthy();
+    expect(fakeServerHandler).toHaveBeenCalledTimes(2);
+    expect(fakeServerHandler).toHaveBeenCalledWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(biddingLogicUrl1),
+      })
+    );
+    expect(fakeServerHandler).toHaveBeenCalledWith(
       jasmine.objectContaining<FakeRequest>({
         url: new URL(trustedBiddingSignalsUrl + "?hostname=www.example.com"),
-        headers: jasmine.objectContaining<{ [name: string]: string }>({
-          "accept": "application/json",
-        }),
-        hasCredentials: false,
       })
     );
   });
 
   it("should log a warning and not fetch trusted scoring signals if URL is ill-formed", async () => {
-    await storeInterestGroup({ name, ads: [ad1, ad2] });
-    const fakeServerHandler =
-      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    await storeInterestGroup({
+      name,
+      biddingLogicUrl: biddingLogicUrl1,
+      ads: [ad1, ad2],
+    });
+    const fakeServerHandler = jasmine
+      .createSpy<FakeServerHandler>("fakeServerHandler")
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+      });
     setFakeServerHandler(fakeServerHandler);
     const consoleSpy = spyOnAllFunctions(console);
     const notUrl = "This string is not a URL.";
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl: notUrl }, hostname)
+      await runAdAuction(
+        { trustedScoringSignalsUrl: notUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
-    expect(fakeServerHandler).not.toHaveBeenCalled();
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(biddingLogicUrl1),
+      })
+    );
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
       jasmine.any(String),
       notUrl
@@ -239,85 +807,220 @@ describe("runAdAuction", () => {
   });
 
   it("should log a warning and not fetch trusted scoring signals if URL has a query string", async () => {
-    await storeInterestGroup({ name, ads: [ad1, ad2] });
-    const fakeServerHandler =
-      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    const fakeServerHandler = jasmine
+      .createSpy<FakeServerHandler>("fakeServerHandler")
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+      });
     setFakeServerHandler(fakeServerHandler);
+    await storeInterestGroup({
+      name,
+      biddingLogicUrl: biddingLogicUrl1,
+      ads: [ad1, ad2],
+    });
     const consoleSpy = spyOnAllFunctions(console);
     const url = trustedScoringSignalsUrl + "?key=value";
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl: url }, hostname)
+      await runAdAuction(
+        { trustedScoringSignalsUrl: url },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
-    expect(fakeServerHandler).not.toHaveBeenCalled();
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(biddingLogicUrl1),
+      })
+    );
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(jasmine.any(String), url);
   });
 
   it("should log a warning if MIME type is wrong", async () => {
-    expect(await storeInterestGroup({ name, ads: [ad1, ad2] })).toBeTrue();
     const mimeType = "text/html";
-    setFakeServerHandler(() =>
-      Promise.resolve({
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl1),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(trustedScoringSignalsUrl + "?keys=about%3Ablank%231"),
+        })
+      )
+      .and.resolveTo({
         headers: {
           "Content-Type": mimeType,
           "X-Allow-FLEDGE": "true",
         },
-        body: '{"a": 1, "b": [true, null]}',
-      })
-    );
+        body: '{"a": 1?}',
+      });
+    setFakeServerHandler(fakeServerHandler);
     const consoleSpy = spyOnAllFunctions(console);
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl }, hostname)
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1, ad2],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction(
+        { trustedScoringSignalsUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
       jasmine.any(String),
-      trustedScoringSignalsUrl + "?keys=about%3Ablank%231,about%3Ablank%232",
+      trustedScoringSignalsUrl + "?keys=about%3Ablank%231",
       jasmine.any(String),
       mimeType
     );
   });
 
   it("should log a warning if JSON is ill-formed", async () => {
-    expect(await storeInterestGroup({ name, ads: [ad1, ad2] })).toBeTrue();
-    setFakeServerHandler(() => Promise.resolve({ headers, body: '{"a": 1?}' }));
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl1),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(trustedScoringSignalsUrl + "?keys=about%3Ablank%231"),
+        })
+      )
+      .and.resolveTo({
+        headers: jsonHeaders,
+        body: '{"a": 1?}',
+      });
+    setFakeServerHandler(fakeServerHandler);
     const consoleSpy = spyOnAllFunctions(console);
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl }, hostname)
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1, ad2],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction(
+        { trustedScoringSignalsUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
       jasmine.any(String),
-      trustedScoringSignalsUrl + "?keys=about%3Ablank%231,about%3Ablank%232",
+      trustedScoringSignalsUrl + "?keys=about%3Ablank%231",
       // Illegal character is at position 7 in the string
       jasmine.stringMatching(/.*\b7\b.*/)
     );
   });
 
   it("should log a warning if JSON value is not an object", async () => {
-    expect(await storeInterestGroup({ name, ads: [ad1, ad2] })).toBeTrue();
-    setFakeServerHandler(() =>
-      Promise.resolve({
-        headers,
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl1),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(trustedScoringSignalsUrl + "?keys=about%3Ablank%231"),
+        })
+      )
+      .and.resolveTo({
+        headers: jsonHeaders,
         body: "3",
-      })
-    );
+      });
+    setFakeServerHandler(fakeServerHandler);
     const consoleSpy = spyOnAllFunctions(console);
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl }, hostname)
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1, ad2],
+      })
+    ).toBeTrue();
+    expect(
+      await runAdAuction(
+        { trustedScoringSignalsUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
     expect(consoleSpy.warn).toHaveBeenCalledOnceWith(
       jasmine.any(String),
-      trustedScoringSignalsUrl + "?keys=about%3Ablank%231,about%3Ablank%232",
+      trustedScoringSignalsUrl + "?keys=about%3Ablank%231",
       jasmine.any(String),
       3
     );
   });
 
-  it("should not log on network error", async () => {
-    expect(await storeInterestGroup({ name, ads: [ad1, ad2] })).toBeTrue();
+  it("should not log on network error when fetching trusted scoring signals", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      })
+    );
     const consoleSpy = spyOnAllFunctions(console);
+    expect(
+      await storeInterestGroup({
+        name,
+        biddingLogicUrl: biddingLogicUrl1,
+        ads: [ad1, ad2],
+      })
+    ).toBeTrue();
     expect(
       await runAdAuction(
         { trustedScoringSignalsUrl: "invalid-scheme://" },
-        hostname
+        hostname,
+        allowedLogicUrlPrefixes
       )
     ).toBeTruthy();
     expect(consoleSpy.error).not.toHaveBeenCalled();
@@ -325,18 +1028,63 @@ describe("runAdAuction", () => {
   });
 
   it("should not log if trusted bidding and scoring signals are fetched successfully", async () => {
+    const fakeServerHandler =
+      jasmine.createSpy<FakeServerHandler>("fakeServerHandler");
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(biddingLogicUrl1),
+        })
+      )
+      .and.resolveTo({
+        headers: javaScriptHeaders,
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#1' };",
+          "}",
+        ].join("\n"),
+      });
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(trustedScoringSignalsUrl + "?keys=about%3Ablank%231"),
+        })
+      )
+      .and.resolveTo(trustedSignalsResponse);
+    fakeServerHandler
+      .withArgs(
+        jasmine.objectContaining<FakeRequest>({
+          url: new URL(trustedBiddingSignalsUrl + "?hostname=www.example.com"),
+        })
+      )
+      .and.resolveTo(trustedSignalsResponse);
+    setFakeServerHandler(fakeServerHandler);
+    const consoleSpy = spyOnAllFunctions(console);
     expect(
       await storeInterestGroup({
         name,
+        biddingLogicUrl: biddingLogicUrl1,
         trustedBiddingSignalsUrl,
         ads: [ad1, ad2],
       })
     ).toBeTrue();
-    setFakeServerHandler(() => Promise.resolve(trustedSignalsResponse));
-    const consoleSpy = spyOnAllFunctions(console);
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl }, hostname)
+      await runAdAuction(
+        { trustedScoringSignalsUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
+    expect(fakeServerHandler).toHaveBeenCalledWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(trustedBiddingSignalsUrl + "?hostname=www.example.com"),
+      })
+    );
+    expect(fakeServerHandler).toHaveBeenCalledWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(trustedScoringSignalsUrl + "?keys=about%3Ablank%231"),
+      })
+    );
     expect(consoleSpy.error).not.toHaveBeenCalled();
     expect(consoleSpy.warn).not.toHaveBeenCalled();
   });
@@ -344,7 +1092,11 @@ describe("runAdAuction", () => {
   it("should not log if there are no ads", async () => {
     const consoleSpy = spyOnAllFunctions(console);
     expect(
-      await runAdAuction({ trustedScoringSignalsUrl }, hostname)
+      await runAdAuction(
+        { trustedScoringSignalsUrl },
+        hostname,
+        allowedLogicUrlPrefixes
+      )
     ).toBeTruthy();
     expect(consoleSpy.error).not.toHaveBeenCalled();
     expect(consoleSpy.warn).not.toHaveBeenCalled();
@@ -353,7 +1105,9 @@ describe("runAdAuction", () => {
   it("should not log if no URL is provided", async () => {
     expect(await storeInterestGroup({ name, ads: [ad1, ad2] })).toBeTrue();
     const consoleSpy = spyOnAllFunctions(console);
-    expect(await runAdAuction({}, hostname)).toBeTruthy();
+    expect(
+      await runAdAuction({}, hostname, allowedLogicUrlPrefixes)
+    ).toBeTruthy();
     expect(consoleSpy.error).not.toHaveBeenCalled();
     expect(consoleSpy.warn).not.toHaveBeenCalled();
   });

--- a/frame/db_schema_test.ts
+++ b/frame/db_schema_test.ts
@@ -18,12 +18,14 @@ describe("db_schema:", () => {
   clearStorageBeforeAndAfter();
 
   const name = "interest group name";
+  const biddingLogicUrl = "https://dsp.example/bidding.js";
   const trustedBiddingSignalsUrl = "https://trusted-server.test/bidding";
 
   describe("forEachInterestGroup", () => {
     it("should read an interest group from IndexedDB", async () => {
       const group = {
         name,
+        biddingLogicUrl,
         trustedBiddingSignalsUrl,
         ads: [{ renderUrl: "about:blank", metadata: { price: 0.02 } }],
       };
@@ -37,15 +39,24 @@ describe("db_schema:", () => {
       expect(
         await useStore("readwrite", (store) => {
           store.add(
-            [trustedBiddingSignalsUrl, [["about:blank#1", 0.01]]],
+            [
+              biddingLogicUrl,
+              trustedBiddingSignalsUrl,
+              [["about:blank#1", 0.01]],
+            ],
             "interest group name 1"
           );
           store.add(
-            ["https://trusted-server-2.test/bidding", []],
+            [
+              "https://dsp-2.example/bidding.js",
+              "https://trusted-server-2.test/bidding",
+              [],
+            ],
             "interest group name 2"
           );
           store.add(
             [
+              /* biddingLogicUrl= */ undefined,
               /* trustedBiddingSignalsUrl= */ undefined,
               [
                 ["about:blank#2", 0.02],
@@ -61,16 +72,19 @@ describe("db_schema:", () => {
       expect(callback).toHaveBeenCalledTimes(3);
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 1",
+        biddingLogicUrl,
         trustedBiddingSignalsUrl,
         ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 2",
+        biddingLogicUrl: "https://dsp-2.example/bidding.js",
         trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
         ads: [],
       });
       expect(callback).toHaveBeenCalledWith({
         name: "interest group name 3",
+        biddingLogicUrl: undefined,
         trustedBiddingSignalsUrl: undefined,
         ads: [
           { renderUrl: "about:blank#2", metadata: { price: 0.02 } },
@@ -84,6 +98,7 @@ describe("db_schema:", () => {
     it("should write an ad that can then be read", async () => {
       const group = {
         name,
+        biddingLogicUrl,
         trustedBiddingSignalsUrl,
         ads: [{ renderUrl: "about:blank", metadata: { price: 0.02 } }],
       };
@@ -99,6 +114,7 @@ describe("db_schema:", () => {
       expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name,
+        biddingLogicUrl: undefined,
         trustedBiddingSignalsUrl: undefined,
         ads: [],
       });
@@ -108,6 +124,7 @@ describe("db_schema:", () => {
       expect(
         await storeInterestGroup({
           name,
+          biddingLogicUrl: "https://dsp-1.example/bidding.js",
           trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
           ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
         })
@@ -115,6 +132,7 @@ describe("db_schema:", () => {
       expect(
         await storeInterestGroup({
           name,
+          biddingLogicUrl: "https://dsp-2.example/bidding.js",
           trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
           ads: [{ renderUrl: "about:blank#2", metadata: { price: 0.02 } }],
         })
@@ -123,6 +141,7 @@ describe("db_schema:", () => {
       expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name,
+        biddingLogicUrl: "https://dsp-2.example/bidding.js",
         trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
         ads: [{ renderUrl: "about:blank#2", metadata: { price: 0.02 } }],
       });
@@ -132,6 +151,7 @@ describe("db_schema:", () => {
       expect(
         await storeInterestGroup({
           name,
+          biddingLogicUrl,
           trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
           ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
         })
@@ -146,6 +166,7 @@ describe("db_schema:", () => {
       expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name,
+        biddingLogicUrl,
         trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
         ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });
@@ -157,6 +178,7 @@ describe("db_schema:", () => {
       expect(
         await storeInterestGroup({
           name: "interest group name 1",
+          biddingLogicUrl: "https://dsp-1.example/bidding.js",
           trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
           ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
         })
@@ -164,6 +186,7 @@ describe("db_schema:", () => {
       expect(
         await storeInterestGroup({
           name: "interest group name 2",
+          biddingLogicUrl: "https://dsp-2.example/bidding.js",
           trustedBiddingSignalsUrl: "https://trusted-server-2.test/bidding",
           ads: [{ renderUrl: "about:blank#2", metadata: { price: 0.02 } }],
         })
@@ -173,6 +196,7 @@ describe("db_schema:", () => {
       expect(await forEachInterestGroup(callback)).toBeTrue();
       expect(callback).toHaveBeenCalledOnceWith({
         name: "interest group name 1",
+        biddingLogicUrl: "https://dsp-1.example/bidding.js",
         trustedBiddingSignalsUrl: "https://trusted-server-1.test/bidding",
         ads: [{ renderUrl: "about:blank#1", metadata: { price: 0.01 } }],
       });

--- a/frame/fetch_test.ts
+++ b/frame/fetch_test.ts
@@ -10,13 +10,18 @@ import {
   FakeServerHandler,
   setFakeServerHandler,
 } from "../testing/http";
-import { FetchJsonResult, FetchJsonStatus, tryFetchJson } from "./fetch";
+import {
+  FetchResult,
+  FetchStatus,
+  tryFetchJavaScript,
+  tryFetchJson,
+} from "./fetch";
 
 describe("tryFetchJson", () => {
   const url = "https://json-endpoint.test/path";
   const body = '{"a": 1, "b": [true, null]}';
   const okResult = {
-    status: FetchJsonStatus.OK as const,
+    status: FetchStatus.OK as const,
     value: { "a": 1, "b": [true, null] },
   };
 
@@ -50,7 +55,7 @@ describe("tryFetchJson", () => {
     setFakeServerHandler(() =>
       Promise.resolve({
         headers: {
-          "Content-Type": "TeXt/JsOn; blah blah blah",
+          "Content-Type": " TeXt/JsOn ; blah blah blah",
           "X-Allow-FLEDGE": "true",
         },
         body,
@@ -58,6 +63,28 @@ describe("tryFetchJson", () => {
     );
     expect(await tryFetchJson(url)).toEqual(okResult);
   });
+
+  for (const mimeType of [
+    // https://mimesniff.spec.whatwg.org/#json-mime-type
+    // Chrome's behavior deviates from the spec here; it only allows +json if
+    // the top-level type is application.
+    "application/arbitrary+json",
+    "application/json",
+    "text/json",
+  ]) {
+    it(`should accept Content-Type: ${mimeType}`, async () => {
+      setFakeServerHandler(() =>
+        Promise.resolve({
+          headers: {
+            "Content-Type": mimeType,
+            "X-Allow-FLEDGE": "true",
+          },
+          body,
+        })
+      );
+      expect(await tryFetchJson(url)).toEqual(okResult);
+    });
+  }
 
   it("should return a validation error on a wrong MIME type", async () => {
     const mimeType = "text/html";
@@ -71,8 +98,8 @@ describe("tryFetchJson", () => {
       })
     );
     expect(await tryFetchJson(url)).toEqual(
-      jasmine.objectContaining<FetchJsonResult>({
-        status: FetchJsonStatus.VALIDATION_ERROR,
+      jasmine.objectContaining<FetchResult<unknown>>({
+        status: FetchStatus.VALIDATION_ERROR,
         errorData: [mimeType],
       })
     );
@@ -87,9 +114,7 @@ describe("tryFetchJson", () => {
         body,
       })
     );
-    expect((await tryFetchJson(url)).status).toBe(
-      FetchJsonStatus.VALIDATION_ERROR
-    );
+    expect((await tryFetchJson(url)).status).toBe(FetchStatus.VALIDATION_ERROR);
   });
 
   it("should accept case-insensitive X-Allow-FLEDGE", async () => {
@@ -117,8 +142,8 @@ describe("tryFetchJson", () => {
       })
     );
     expect(await tryFetchJson(url)).toEqual(
-      jasmine.objectContaining<FetchJsonResult>({
-        status: FetchJsonStatus.VALIDATION_ERROR,
+      jasmine.objectContaining<FetchResult<unknown>>({
+        status: FetchStatus.VALIDATION_ERROR,
         errorData: [xAllowFledge],
       })
     );
@@ -128,9 +153,7 @@ describe("tryFetchJson", () => {
     setFakeServerHandler(() =>
       Promise.resolve({ headers: { "Content-Type": "application/json" }, body })
     );
-    expect((await tryFetchJson(url)).status).toBe(
-      FetchJsonStatus.VALIDATION_ERROR
-    );
+    expect((await tryFetchJson(url)).status).toBe(FetchStatus.VALIDATION_ERROR);
   });
 
   it("should return a validation error on ill-formed JSON", async () => {
@@ -144,7 +167,7 @@ describe("tryFetchJson", () => {
       })
     );
     expect(await tryFetchJson(url)).toEqual({
-      status: FetchJsonStatus.VALIDATION_ERROR,
+      status: FetchStatus.VALIDATION_ERROR,
       // Illegal character is at position 7 in the string
       errorMessage: jasmine.stringMatching(/.*\b7\b.*/),
     });
@@ -152,7 +175,7 @@ describe("tryFetchJson", () => {
 
   it("should handle a network error on the initial fetch", async () => {
     expect(await tryFetchJson("invalid-scheme://")).toEqual({
-      status: FetchJsonStatus.NETWORK_ERROR,
+      status: FetchStatus.NETWORK_ERROR,
     });
   });
 
@@ -167,7 +190,7 @@ describe("tryFetchJson", () => {
       })
     );
     expect(await tryFetchJson(url)).toEqual({
-      status: FetchJsonStatus.NETWORK_ERROR,
+      status: FetchStatus.NETWORK_ERROR,
     });
   });
 
@@ -185,7 +208,207 @@ describe("tryFetchJson", () => {
       });
     setFakeServerHandler(fakeServerHandler);
     expect(await tryFetchJson(url)).toEqual({
-      status: FetchJsonStatus.NETWORK_ERROR,
+      status: FetchStatus.NETWORK_ERROR,
+    });
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining<FakeRequest>({ url: new URL(url) })
+    );
+  });
+});
+
+describe("tryFetchJavaScript", () => {
+  const url = "https://js-endpoint.test/path.js";
+  const body = "postMessage('Hello World!')";
+  const okResult = {
+    status: FetchStatus.OK as const,
+    value: body,
+  };
+
+  it("should fetch a script", async () => {
+    const fakeServerHandler = jasmine
+      .createSpy<FakeServerHandler>()
+      .and.resolveTo({
+        headers: {
+          "Content-Type": "application/javascript",
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      });
+    setFakeServerHandler(fakeServerHandler);
+    const result = await tryFetchJavaScript(url);
+    expect(result).toEqual(okResult);
+    expect(fakeServerHandler).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining<FakeRequest>({
+        url: new URL(url),
+        method: "GET",
+        headers: jasmine.objectContaining<{ [name: string]: string }>({
+          "accept": "application/javascript",
+        }),
+        body: Uint8Array.of(),
+        hasCredentials: false,
+      })
+    );
+  });
+
+  it("should accept case-insensitive Content-Type", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": " TeXt/X-EcMaScRiPt ; blah blah blah",
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      })
+    );
+    expect(await tryFetchJavaScript(url)).toEqual(okResult);
+  });
+
+  for (const mimeType of [
+    // https://mimesniff.spec.whatwg.org/#javascript-mime-type
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "text/ecmascript",
+    "text/javascript",
+    "text/javascript1.0",
+    "text/javascript1.1",
+    "text/javascript1.2",
+    "text/javascript1.3",
+    "text/javascript1.4",
+    "text/javascript1.5",
+    "text/jscript",
+    "text/livescript",
+    "text/x-ecmascript",
+    "text/x-javascript",
+  ]) {
+    it(`should accept Content-Type: ${mimeType}`, async () => {
+      setFakeServerHandler(() =>
+        Promise.resolve({
+          headers: {
+            "Content-Type": mimeType,
+            "X-Allow-FLEDGE": "true",
+          },
+          body,
+        })
+      );
+      expect(await tryFetchJavaScript(url)).toEqual(okResult);
+    });
+  }
+
+  it("should return a validation error on a wrong MIME type", async () => {
+    const mimeType = "text/html";
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": mimeType,
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      })
+    );
+    expect(await tryFetchJavaScript(url)).toEqual(
+      jasmine.objectContaining<FetchResult<unknown>>({
+        status: FetchStatus.VALIDATION_ERROR,
+        errorData: [mimeType],
+      })
+    );
+  });
+
+  it("should return a validation error on a missing MIME type", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      })
+    );
+    expect((await tryFetchJavaScript(url)).status).toBe(
+      FetchStatus.VALIDATION_ERROR
+    );
+  });
+
+  it("should accept case-insensitive X-Allow-FLEDGE", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "application/javascript",
+          "X-Allow-FLEDGE": "tRuE",
+        },
+        body,
+      })
+    );
+    expect(await tryFetchJavaScript(url)).toEqual(okResult);
+  });
+
+  it("should return a validation error on a wrong X-Allow-FLEDGE header", async () => {
+    const xAllowFledge = "nope";
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "application/javascript",
+          "X-Allow-FLEDGE": xAllowFledge,
+        },
+        body,
+      })
+    );
+    expect(await tryFetchJavaScript(url)).toEqual(
+      jasmine.objectContaining<FetchResult<unknown>>({
+        status: FetchStatus.VALIDATION_ERROR,
+        errorData: [xAllowFledge],
+      })
+    );
+  });
+
+  it("should return a validation error on a missing MIME type", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: { "Content-Type": "application/javascript" },
+        body,
+      })
+    );
+    expect((await tryFetchJavaScript(url)).status).toBe(
+      FetchStatus.VALIDATION_ERROR
+    );
+  });
+
+  it("should handle a network error on the initial fetch", async () => {
+    expect(await tryFetchJavaScript("invalid-scheme://")).toEqual({
+      status: FetchStatus.NETWORK_ERROR,
+    });
+  });
+
+  it("should handle a network error when reading the body", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "application/javascript",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: null,
+      })
+    );
+    expect(await tryFetchJavaScript(url)).toEqual({
+      status: FetchStatus.NETWORK_ERROR,
+    });
+  });
+
+  it("should return a network error on redirect and not follow it", async () => {
+    const fakeServerHandler = jasmine
+      .createSpy<FakeServerHandler>()
+      .and.resolveTo({
+        status: 302,
+        headers: {
+          "Location": "https://js-endpoint.test/redirected.js",
+          "Content-Type": "application/javascript",
+          "X-Allow-FLEDGE": "true",
+        },
+        body,
+      });
+    setFakeServerHandler(fakeServerHandler);
+    expect(await tryFetchJavaScript(url)).toEqual({
+      status: FetchStatus.NETWORK_ERROR,
     });
     expect(fakeServerHandler).toHaveBeenCalledOnceWith(
       jasmine.objectContaining<FakeRequest>({ url: new URL(url) })

--- a/frame/main_test.ts
+++ b/frame/main_test.ts
@@ -21,6 +21,7 @@ import {
   assertToSatisfyTypeGuard,
 } from "../testing/assert";
 import { cleanDomAfterEach } from "../testing/dom";
+import { setFakeServerHandler } from "../testing/http";
 import { clearStorageBeforeAndAfter } from "../testing/storage";
 import { main } from "./main";
 
@@ -28,14 +29,28 @@ describe("main", () => {
   cleanDomAfterEach();
   clearStorageBeforeAndAfter();
 
+  const allowedLogicUrlPrefixesJoined = "https://dsp.test/";
   const renderUrl = "about:blank#ad";
 
   it("should connect to parent window and handle requests from it", async () => {
+    setFakeServerHandler(() =>
+      Promise.resolve({
+        headers: {
+          "Content-Type": "application/javascript",
+          "X-Allow-FLEDGE": "true",
+        },
+        body: [
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#ad' };",
+          "}",
+        ].join("\n"),
+      })
+    );
     const iframe = document.createElement("iframe");
     document.body.appendChild(iframe);
     const handshakeMessageEventPromise = awaitMessageFromSelfToSelf();
     assertToBeTruthy(iframe.contentWindow);
-    main(iframe.contentWindow);
+    main(iframe.contentWindow, allowedLogicUrlPrefixesJoined);
     const handshakeMessageEvent = await handshakeMessageEventPromise;
     assertToBeTruthy(handshakeMessageEvent);
     expect(handshakeMessageEvent.data).toEqual({ [VERSION_KEY]: VERSION });
@@ -46,6 +61,7 @@ describe("main", () => {
         kind: RequestKind.JOIN_AD_INTEREST_GROUP,
         group: {
           name: "interest group name",
+          biddingLogicUrl: "https://dsp.test/bidder.js",
           ads: [{ renderUrl, metadata: { price: 0.02 } }],
         },
       })
@@ -72,7 +88,7 @@ describe("main", () => {
     outerIframe.src = "about:blank#" + token;
     document.body.appendChild(outerIframe);
     assertToBeTruthy(outerIframe.contentWindow);
-    main(outerIframe.contentWindow);
+    main(outerIframe.contentWindow, allowedLogicUrlPrefixesJoined);
     const innerIframe =
       outerIframe.contentWindow.document.querySelector("iframe");
     assertToBeTruthy(innerIframe);
@@ -87,7 +103,7 @@ describe("main", () => {
     outerIframe.style.height = "45px";
     document.body.appendChild(outerIframe);
     assertToBeTruthy(outerIframe.contentWindow);
-    main(outerIframe.contentWindow);
+    main(outerIframe.contentWindow, allowedLogicUrlPrefixesJoined);
     const innerIframe =
       outerIframe.contentWindow.document.querySelector("iframe");
     assertToBeTruthy(innerIframe);
@@ -124,7 +140,7 @@ describe("main", () => {
     document.body.appendChild(iframe);
     const win = iframe.contentWindow;
     assertToBeTruthy(win);
-    main(win);
+    main(win, allowedLogicUrlPrefixesJoined);
     expect(consoleSpy.error).toHaveBeenCalledOnceWith(
       jasmine.any(String),
       "#" + token
@@ -133,7 +149,34 @@ describe("main", () => {
 
   it("should log an error if running on top window", () => {
     const consoleSpy = spyOnAllFunctions(console);
-    main(top);
+    main(top, allowedLogicUrlPrefixesJoined);
     expect(consoleSpy.error).toHaveBeenCalledOnceWith(jasmine.any(String));
+  });
+
+  it("should log an error if allowlisted logic URL prefix is not a valid absolute URL", () => {
+    const consoleSpy = spyOnAllFunctions(console);
+    main(window, "/relative/");
+    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
+      "/relative/"
+    );
+  });
+
+  it("should log an error if allowlisted logic URL prefix does not end with a slash", () => {
+    const consoleSpy = spyOnAllFunctions(console);
+    main(window, "https://dsp.test");
+    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
+      "https://dsp.test"
+    );
+  });
+
+  it("should log an error if allowlisted logic URL prefix is insecure HTTP", () => {
+    const consoleSpy = spyOnAllFunctions(console);
+    main(window, "http://insecure-dsp.test/");
+    expect(consoleSpy.error).toHaveBeenCalledOnceWith(
+      jasmine.any(String),
+      "http://insecure-dsp.test/"
+    );
   });
 });

--- a/frame/types.ts
+++ b/frame/types.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview CRUD operations on our data model for persistent storage in
+ * IndexedDB, with runtime type checking.
+ */
+
+import { AuctionAd } from "../lib/shared/api_types";
+
+/**
+ * Analogous to `InterestGroup` from `../lib/shared/api_types`, but all fields
+ * are required. This represents an interest group as it is stored and used
+ * internally.
+ */
+export interface CanonicalInterestGroup {
+  name: string;
+  biddingLogicUrl: string | undefined;
+  trustedBiddingSignalsUrl: string | undefined;
+  ads: AuctionAd[];
+}
+
+/**
+ * A bid returned by `generateBid` in a bidding script.
+ *
+ * @see https://github.com/WICG/turtledove/blob/main/FLEDGE.md#32-on-device-bidding
+ */
+export interface BidData {
+  /**
+   * The amount that the buyer is willing to pay in order to have this ad
+   * selected. The highest bid is selected; in case of a tie, one of the highest
+   * bids is selected based on database order.
+   *
+   * Browser-native implementations of FLEDGE will instead pass each bid to be
+   * evaluated by a decision script.
+   *
+   * The precise meaning of this value (what currency it's in, CPM vs. CPC,
+   * etc.) is a matter of convention among buyers and sellers. The current
+   * implementation requires the entire ecosystem to adopt a uniform
+   * convention, which is impractical, but future implementations will allow
+   * sellers to choose which buyers to transact with, which will allow them to
+   * deal only with buyers with whom they've made out-of-band agreements that
+   * specify the meaning.
+   */
+  bid: number;
+  /**
+   * The URL where the actual creative is hosted. This will be used as the `src`
+   * of an iframe that will appear on the page if this ad wins.
+   */
+  render: string;
+}

--- a/frame/worklet.ts
+++ b/frame/worklet.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Utilities for running code in a worklet-like environment.
+ * (Browser-native implementations of FLEDGE will use real worklets, but
+ * JavaScript code can't create custom worklets, so we use Web Workers instead.)
+ */
+
+import { isArray } from "../lib/shared/guards";
+import { awaitMessageToWorker } from "../lib/shared/messaging";
+import { BidData, CanonicalInterestGroup } from "./types";
+
+/**
+ * Interprets `biddingScript` as JavaScript code and runs it in a worklet-like
+ * Web Worker environment, then calls its `generateBid` function and returns the
+ * result, or null if any exceptions or validation errors occur. (Such errors
+ * are logged, either inside or outside the Web Worker.)
+ *
+ * We take defensive measures to prevent misbehaving scripts from corrupting the
+ * frame's own state, but we do *not* defend against exfiltration. If an
+ * untrusted domain or path is included in `ALLOWED_LOGIC_URL_PREFIXES`, then
+ * scripts served from that domain or path can be passed here and can see and
+ * exfiltrate interest groups and associated data.
+ *
+ * @param group The originating interest group, passed through to generateBid.
+ * @param extraScript Additional JavaScript code to run in the Web Worker before
+ * anything else. In production, this is always empty; in tests, it's used to
+ * stub out `console.warn`.
+ */
+export async function runBiddingScript(
+  biddingScript: string,
+  group: CanonicalInterestGroup,
+  extraScript: string
+): Promise<BidData | null> {
+  const worker = new Worker(
+    "data:application/javascript," +
+      encodeURIComponent(
+        [
+          extraScript,
+          // Comments are inside the quotes to avoid awkward indentation.
+          "((biddingScript, group) => {",
+          "  // Get local bindings to globals that we might use after",
+          "  // biddingScript runs, so that it can't overwrite them.",
+          "  const global = self;",
+          "  const postMsg = postMessage;",
+          "  // If warnings need to be logged, we do so from inside the worker",
+          "  // in order to avoid losing context in transit with postMessage.",
+          "  const { warn } = console;",
+          "  function handleError(message, data) {",
+          "    warn('[FLEDGE Shim] ' + message, data);",
+          "    postMsg([]);",
+          "  }",
+          "  // Don't let biddingScript send messages to the window; only",
+          "  // our code should do that.",
+          "  delete postMessage;",
+          "  const biddingScriptErrorMessage = 'Error in bidding script:'",
+          "  let generateBid;",
+          "  try {",
+          "    // Run biddingScript in its own scope without access to",
+          "    // this code's locals.",
+          "    importScripts(",
+          "      'data:application/javascript,' +",
+          "        encodeURIComponent(biddingScript)",
+          "    );",
+          "    // After the script runs, any property might have been",
+          "    // monkeypatched with an ill-behaved getter, so all further",
+          "    // property accesses are in try blocks.",
+          "    generateBid = global['generateBid'];",
+          "  } catch (error) {",
+          "    handleError(biddingScriptErrorMessage, error);",
+          "    return;",
+          "  }",
+          "  if (typeof generateBid !== 'function') {",
+          "    handleError('generateBid is not a function:', generateBid);",
+          "    return;",
+          "  }",
+          "  let bidData;",
+          "  let bid;",
+          "  let render;",
+          "  try {",
+          "    bidData = generateBid(group);",
+          "    bid = bidData?.['bid'];",
+          "    render = bidData?.['render'];",
+          "  } catch (error) {",
+          "    handleError(biddingScriptErrorMessage, error);",
+          "    return;",
+          "  }",
+          "  if (",
+          "    !(typeof bid === 'number' && typeof render === 'string')",
+          "  ) {",
+          "    handleError(",
+          "      'generateBid did not return valid bid data:',",
+          "      bidData",
+          "    );",
+          "    return;",
+          "  }",
+          "  postMsg([bid, render]);",
+          `})(${JSON.stringify(biddingScript)}, ${JSON.stringify(group)});`,
+        ].join("\n")
+      )
+  );
+  let message;
+  try {
+    message = await awaitMessageToWorker(worker);
+  } finally {
+    worker.terminate();
+  }
+  // It shouldn't be possible for a messageerror to occur or for message data
+  // to be of the wrong type; biddingScript has no access to postMessage, and
+  // the outer script type-checks values before sending them.
+  /* istanbul ignore if */
+  if (!message) {
+    throw new Error();
+  }
+  const { data } = message;
+  /* istanbul ignore if */
+  if (!isArray(data)) {
+    throw new Error(String(data));
+  }
+  switch (data.length) {
+    case 0:
+      return null;
+    case 2: {
+      const [bid, render] = data;
+      /* istanbul ignore if */
+      if (!(typeof bid === "number" && typeof render === "string")) {
+        throw new Error(String(data));
+      }
+      return { bid, render };
+    }
+    /* istanbul ignore next */
+    default:
+      throw new Error(String(data));
+  }
+}

--- a/frame/worklet_test.ts
+++ b/frame/worklet_test.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { setFakeServerHandler } from "../testing/http";
+import { runBiddingScript } from "./worklet";
+
+describe("bid", () => {
+  const group = {
+    name: "interest group name",
+    biddingLogicUrl: "https://dsp.test/bidder.js",
+    trustedBiddingSignalsUrl: "https://trusted-server.test/bidding",
+    ads: [
+      { renderUrl: "about:blank#1", metadata: { price: 0.01 } },
+      { renderUrl: "about:blank#2", metadata: { price: 0.02 } },
+    ],
+  };
+
+  it("should run a bidding script", async () => {
+    expect(
+      await runBiddingScript(
+        [
+          "function generateBid({",
+          "  name,",
+          "  biddingLogicUrl,",
+          "  trustedBiddingSignalsUrl,",
+          "  ads,",
+          "}) {",
+          "  if (",
+          "    !(",
+          "      name === 'interest group name' &&",
+          "      biddingLogicUrl === 'https://dsp.test/bidder.js' &&",
+          "      trustedBiddingSignalsUrl ===",
+          "        'https://trusted-server.test/bidding' &&",
+          "      ads.length === 2 &&",
+          "      ads[0].renderUrl === 'about:blank#1' &&",
+          "      ads[0].metadata.price === 0.01 &&",
+          "      ads[1].renderUrl === 'about:blank#2' &&",
+          "      ads[1].metadata.price === 0.02 &&",
+          "      origin === 'null'",
+          "    )",
+          "  ) {",
+          "    throw new Error();",
+          "  }",
+          "  return { bid: 0.03, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+        group,
+        /* extraScript= */ ""
+      )
+    ).toEqual({ bid: 0.03, render: "about:blank#2" });
+  });
+
+  it("should ignore monkeypatching of built-in properties", async () => {
+    expect(
+      await runBiddingScript(
+        [
+          "for (const { obj, property } of [",
+          "  { obj: WorkerGlobalScope.prototype, property: 'self' },",
+          "  { obj: globalThis, property: 'postMessage' },",
+          "  { obj: console, property: 'warn' },",
+          "]) {",
+          "  Object.defineProperty(obj, property, {",
+          "    get() {",
+          "      throw new Error();",
+          "    },",
+          "  });",
+          "}",
+          "function generateBid() {",
+          "  return { bid: 0.03, render: 'about:blank#2' };",
+          "}",
+        ].join("\n"),
+        group,
+        /* extraScript= */ ""
+      )
+    ).toEqual({ bid: 0.03, render: "about:blank#2" });
+  });
+
+  for (const { condition, biddingScript, warningData } of [
+    {
+      condition: "generateBid is the wrong type",
+      biddingScript: "generateBid = true;",
+      warningData: "true",
+    },
+    {
+      condition: "generateBid returns nullish",
+      biddingScript: "function generateBid() { return null; }",
+      warningData: "null",
+    },
+    {
+      condition: "bid is the wrong type",
+      biddingScript: [
+        "function generateBid() {",
+        "  return { bid: 'nope', render: 'about:blank#2' };",
+        "}",
+      ].join("\n"),
+      warningData: "[object Object]",
+    },
+    {
+      condition: "render is the wrong type",
+      biddingScript: [
+        "function generateBid() {",
+        "  return { bid: 0.03, render: 42 };",
+        "}",
+      ].join("\n"),
+      warningData: "[object Object]",
+    },
+    {
+      condition: "top-level script throws",
+      biddingScript: "throw new Error('Oops');",
+      warningData: "Error: Oops",
+    },
+    {
+      condition: "generateBid throws",
+      biddingScript: [
+        "function generateBid() {",
+        "  throw new Error('Oops');",
+        "}",
+      ].join("\n"),
+      warningData: "Error: Oops",
+    },
+    {
+      condition: "generateBid property access throws",
+      biddingScript: [
+        "Object.defineProperty(globalThis, 'generateBid', {",
+        "  get() {",
+        "    throw new Error('Oops');",
+        "  }",
+        "});",
+      ].join("\n"),
+      warningData: "Error: Oops",
+    },
+    {
+      condition: "bid property access throws",
+      biddingScript: [
+        "function generateBid() {",
+        "  return {",
+        "    get bid() {",
+        "      throw new Error('Oops');",
+        "    },",
+        "    render: 'about:blank#2',",
+        "  };",
+        "}",
+      ].join("\n"),
+      warningData: "Error: Oops",
+    },
+    {
+      condition: "render property access throws",
+      biddingScript: [
+        "function generateBid() {",
+        "  return {",
+        "    bid: 0.03,",
+        "    get render() {",
+        "      throw new Error('Oops');",
+        "    },",
+        "  };",
+        "}",
+      ].join("\n"),
+      warningData: "Error: Oops",
+    },
+    {
+      condition: "script tries to postMessage",
+      biddingScript: [
+        "postMessage([null]);",
+        "function generateBid() {",
+        "  return { bid: 0.03, render: 'about:blank#2' };",
+        "}",
+      ].join("\n"),
+      warningData: jasmine.stringMatching(/^ReferenceError: .*/),
+    },
+  ]) {
+    it(`should log a warning and drop the bid if ${condition}`, async () => {
+      const warningPromise = new Promise((resolve) => {
+        setFakeServerHandler(({ body }) => {
+          resolve(JSON.parse(new TextDecoder().decode(body)));
+          return Promise.resolve({});
+        });
+      });
+      expect(
+        await runBiddingScript(
+          biddingScript,
+          group,
+          [
+            "console.warn = (...args) => {",
+            "  void fetch('https://warning.test', {",
+            "    method: 'POST',",
+            "    body: JSON.stringify(args.map(String)),",
+            "    keepalive: true,",
+            "  });",
+            "};",
+          ].join("\n")
+        )
+      ).toBeNull();
+      expect(await warningPromise).toEqual([jasmine.any(String), warningData]);
+    });
+  }
+});

--- a/frame_entry_point.ts
+++ b/frame_entry_point.ts
@@ -11,4 +11,10 @@
 
 import { main } from "./frame/main";
 
-main(window);
+const allowedLogicUrlPrefixesJoined = process.env.ALLOWED_LOGIC_URL_PREFIXES;
+// It shouldn't be possible for this to be undefined; Webpack will fail the
+// build if no value is provided.
+if (allowedLogicUrlPrefixesJoined === undefined) {
+  throw new Error();
+}
+main(window, allowedLogicUrlPrefixesJoined);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,6 +7,11 @@
 const webpack = require("webpack");
 const webpackDevMiddleware = require("webpack-dev-middleware");
 
+// This specifically affects the frame served by webpack-dev-middleware,
+// which lib/public_api_test.ts depends on.
+process.env.ALLOWED_LOGIC_URL_PREFIXES =
+  "https://dsp.test/,https://dsp-1.test/,https://dsp-2.test/";
+
 module.exports = (config) => {
   config.set({
     plugins: [

--- a/lib/public_api.ts
+++ b/lib/public_api.ts
@@ -148,8 +148,13 @@ export class FledgeShim {
       kind: RequestKind.JOIN_AD_INTEREST_GROUP,
       group: {
         ...group,
-        trustedBiddingSignalsUrl: absoluteTrustedSignalsUrl(
-          group.trustedBiddingSignalsUrl
+        biddingLogicUrl: absoluteHttpsUrl(
+          group.biddingLogicUrl,
+          /* allowQueryString= */ true
+        ),
+        trustedBiddingSignalsUrl: absoluteHttpsUrl(
+          group.trustedBiddingSignalsUrl,
+          /* allowQueryString= */ false
         ),
       },
     });
@@ -221,8 +226,9 @@ export class FledgeShim {
       kind: RequestKind.RUN_AD_AUCTION,
       config: {
         ...config,
-        trustedScoringSignalsUrl: absoluteTrustedSignalsUrl(
-          config.trustedScoringSignalsUrl
+        trustedScoringSignalsUrl: absoluteHttpsUrl(
+          config.trustedScoringSignalsUrl,
+          /* allowQueryString= */ false
         ),
       },
     });
@@ -253,7 +259,7 @@ function absoluteUrl(url: string) {
   }
 }
 
-function absoluteTrustedSignalsUrl(url: string | undefined) {
+function absoluteHttpsUrl(url: string | undefined, allowQueryString: boolean) {
   if (url === undefined) {
     return undefined;
   }
@@ -261,7 +267,7 @@ function absoluteTrustedSignalsUrl(url: string | undefined) {
   if (parsedUrl.protocol !== "https:") {
     throw new Error("Only https: URLs allowed: " + url);
   }
-  if (parsedUrl.search) {
+  if (!allowQueryString && parsedUrl.search) {
     throw new Error("URL query string not allowed: " + url);
   }
   return parsedUrl.href;

--- a/lib/shared/api_types.ts
+++ b/lib/shared/api_types.ts
@@ -28,8 +28,7 @@ export interface AuctionAd {
     /**
      * The amount that the buyer is willing to pay in order to have this ad
      * selected. The ad with the highest price is selected; in case of a tie, an
-     * ad with the highest price is selected arbitrarily (based on IndexedDB
-     * implementation details).
+     * ad with the highest price is selected based on database order.
      *
      * This is used by our temporary hardcoded auction logic and will not exist
      * in browser-native implementations of FLEDGE (in which auction logic, and
@@ -58,6 +57,15 @@ export interface AuctionAdInterestGroup {
    * that can be used to refer to it in order to update or delete it later.
    */
   name: string;
+  /**
+   * An HTTPS URL. At auction time, the bidding script is fetched from here and
+   * its `generateBid` function is called in an isolated worklet-like
+   * environment. The script must be served with a JavaScript MIME type and with
+   * the header `X-FLEDGE-Shim: true`, and its URL must begin with one of the
+   * prefixes specified when building the frame. If undefined, this interest
+   * group is silently skipped.
+   */
+  biddingLogicUrl?: string;
   /**
    * An HTTPS URL with no query string. If provided, a request to this URL is
    * made at auction time. The response is expected to be a JSON object.

--- a/lib/shared/messaging.ts
+++ b/lib/shared/messaging.ts
@@ -42,6 +42,17 @@ export async function awaitMessageToPort(
   }
 }
 
+/**
+ * Returns a promise that resolves to the first `MessageEvent` sent to `worker`
+ * via `postMessage` in `worker`'s global scope, or to null if a deserialization
+ * error occurs.
+ */
+export function awaitMessageToWorker(
+  worker: Worker
+): Promise<MessageEvent<unknown> | null> {
+  return awaitMessage(worker, () => true);
+}
+
 function awaitMessage(
   target: MessageTarget,
   filter: (event: MessageEvent<unknown>) => boolean

--- a/lib/shared/protocol.ts
+++ b/lib/shared/protocol.ts
@@ -45,13 +45,21 @@ export function requestFromMessageData(
   const [kind] = messageData;
   switch (kind) {
     case RequestKind.JOIN_AD_INTEREST_GROUP: {
-      if (messageData.length !== 4) {
+      if (messageData.length !== 5) {
         return null;
       }
-      const [, name, trustedBiddingSignalsUrl, adsMessageData] = messageData;
+      const [
+        ,
+        name,
+        biddingLogicUrl,
+        trustedBiddingSignalsUrl,
+        adsMessageData,
+      ] = messageData;
       if (
         !(
           typeof name === "string" &&
+          (biddingLogicUrl === undefined ||
+            typeof biddingLogicUrl === "string") &&
           (trustedBiddingSignalsUrl === undefined ||
             typeof trustedBiddingSignalsUrl === "string")
         )
@@ -74,7 +82,10 @@ export function requestFromMessageData(
       } else if (adsMessageData !== undefined) {
         return null;
       }
-      return { kind, group: { name, trustedBiddingSignalsUrl, ads } };
+      return {
+        kind,
+        group: { name, biddingLogicUrl, trustedBiddingSignalsUrl, ads },
+      };
     }
     case RequestKind.LEAVE_AD_INTEREST_GROUP: {
       if (messageData.length !== 2) {
@@ -112,11 +123,12 @@ export function messageDataFromRequest(request: FledgeRequest): unknown {
     case RequestKind.JOIN_AD_INTEREST_GROUP: {
       const {
         kind,
-        group: { name, trustedBiddingSignalsUrl, ads },
+        group: { name, biddingLogicUrl, trustedBiddingSignalsUrl, ads },
       } = request;
       return [
         kind,
         name,
+        biddingLogicUrl,
         trustedBiddingSignalsUrl,
         ads?.map(({ renderUrl: renderUrl, metadata: { price } }) => [
           renderUrl,

--- a/lib/shared/protocol_test.ts
+++ b/lib/shared/protocol_test.ts
@@ -17,15 +17,27 @@ const requests: Array<{ request: FledgeRequest; messageData: unknown }> = [
   {
     request: {
       kind: RequestKind.JOIN_AD_INTEREST_GROUP,
-      group: { name: "", trustedBiddingSignalsUrl: undefined, ads: undefined },
+      group: {
+        name: "",
+        biddingLogicUrl: undefined,
+        trustedBiddingSignalsUrl: undefined,
+        ads: undefined,
+      },
     },
-    messageData: [RequestKind.JOIN_AD_INTEREST_GROUP, "", undefined, undefined],
+    messageData: [
+      RequestKind.JOIN_AD_INTEREST_GROUP,
+      "",
+      undefined,
+      undefined,
+      undefined,
+    ],
   },
   {
     request: {
       kind: RequestKind.JOIN_AD_INTEREST_GROUP,
       group: {
         name: "interest group name",
+        biddingLogicUrl: "https://dsp.example/bidder.js",
         trustedBiddingSignalsUrl: "https://trusted-server.example/bidding",
         ads: [
           { renderUrl: "https://ad.example/1", metadata: { price: 0.02 } },
@@ -36,6 +48,7 @@ const requests: Array<{ request: FledgeRequest; messageData: unknown }> = [
     messageData: [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       [
         ["https://ad.example/1", 0.02],
@@ -91,11 +104,13 @@ describe("requestFromMessageData", () => {
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
     ],
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       [],
       42,
@@ -103,31 +118,49 @@ describe("requestFromMessageData", () => {
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       [],
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       [],
     ],
-    [RequestKind.JOIN_AD_INTEREST_GROUP, "interest group name", {}, []],
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      {},
+      "https://trusted-server.example/bidding",
+      [],
+    ],
+    [
+      RequestKind.JOIN_AD_INTEREST_GROUP,
+      "interest group name",
+      "https://dsp.example/bidder.js",
+      42,
+      [],
+    ],
+    [
+      RequestKind.JOIN_AD_INTEREST_GROUP,
+      "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       "nope",
     ],
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       [null],
     ],
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       [["https://ad.example/1", 0.02], []],
     ],
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       [
         ["https://ad.example/1", 0.02, true],
@@ -137,6 +170,7 @@ describe("requestFromMessageData", () => {
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       [
         ["https://ad.example/1", 0.02],
@@ -147,6 +181,7 @@ describe("requestFromMessageData", () => {
     [
       RequestKind.JOIN_AD_INTEREST_GROUP,
       "interest group name",
+      "https://dsp.example/bidder.js",
       "https://trusted-server.example/bidding",
       [
         ["https://ad.example/1", 0.02],
@@ -189,6 +224,7 @@ describe("messageDataFromRequest", () => {
       "interest group name",
       undefined,
       undefined,
+      undefined,
     ]);
   });
 
@@ -198,6 +234,7 @@ describe("messageDataFromRequest", () => {
         kind: RequestKind.LEAVE_AD_INTEREST_GROUP,
         group: {
           name: "interest group name",
+          biddingLogicUrl: "https://dsp.example/bidder.js",
           trustedBiddingSignalsUrl: "https://trusted-server.example/bidding",
           ads: [
             { renderUrl: "https://ad.example/1", metadata: { price: 0.02 } },

--- a/testing/http_test.ts
+++ b/testing/http_test.ts
@@ -63,6 +63,11 @@ describe("setFakeServerHandler", () => {
     );
   });
 
+  it("should reject on a null response", async () => {
+    setFakeServerHandler(() => Promise.resolve(null));
+    await expectAsync(fetch(url)).toBeRejectedWithError(TypeError);
+  });
+
   it("should reject when attempting to read a null body", async () => {
     const status = 206;
     const statusText = "Custom Status";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const InlineChunkHtmlPlugin = require("react-dev-utils/InlineChunkHtmlPlugin");
 const path = require("path");
+const { EnvironmentPlugin } = require("webpack");
 
 module.exports = {
   entry: path.resolve(__dirname, "frame_entry_point.ts"),
@@ -14,6 +15,7 @@ module.exports = {
   module: { rules: [{ test: /\.ts$/, loader: "ts-loader" }] },
   resolve: { extensions: [".ts"] },
   plugins: [
+    new EnvironmentPlugin(["ALLOWED_LOGIC_URL_PREFIXES"]),
     new HtmlWebpackPlugin({
       filename: "frame.html",
       template: path.resolve(__dirname, "frame.html"),


### PR DESCRIPTION
This is the minimum working implementation. Features to be added later include:
- Arbitrary metadata instead of just a static price (#147)
- trustedBiddingSignalsKeys (#148)
- auctionSignals (#149)
- browserSignals (#150)
- Timeouts (#151)
- Deduplication of script fetches (#152)
- Optimization of worker support code (#153)
- Public TypeScript typings for worklet script authors (#154)

Fixes: #20