### PR TITLE
Import api_types directly in protocol.ts

### DIFF
--- a/lib/shared/protocol.ts
+++ b/lib/shared/protocol.ts
@@ -14,7 +14,7 @@ import {
   AuctionAd,
   AuctionAdConfig,
   AuctionAdInterestGroup,
-} from "../public_api";
+} from "./api_types";
 import { isArray } from "./guards";
 
 /**


### PR DESCRIPTION
This should have been done all along but was an oversight. It avoids package-level dependency cycles when building with Bazel.