### PR TITLE
Replace Symbol.species with Symbol.iterator in tests

### DIFF
--- a/frame/worklet_test.ts
+++ b/frame/worklet_test.ts
@@ -63,7 +63,7 @@ describe("runBiddingScript", () => {
     { expression: "{}", adJson: "{}" },
     { expression: "[undefined]", adJson: "[null]" },
     { expression: "[null]", adJson: "[null]" },
-    { expression: "[Symbol.species]", adJson: "[null]" },
+    { expression: "[Symbol.iterator]", adJson: "[null]" },
     { expression: "[() => {}]", adJson: "[null]" },
     { expression: "/abc/", adJson: "{}" },
     { expression: "new (class {})()", adJson: "{}" },
@@ -137,7 +137,7 @@ describe("runBiddingScript", () => {
       condition: "ad is a symbol",
       biddingScript: [
         "function generateBid() {",
-        "  return { ad: Symbol.species, bid: 0.03, render: 'about:blank#2' };",
+        "  return { ad: Symbol.iterator, bid: 0.03, render: 'about:blank#2' };",
         "}",
       ].join("\n"),
       warningData: "[object Object]",

--- a/lib/shared/protocol_test.ts
+++ b/lib/shared/protocol_test.ts
@@ -258,7 +258,7 @@ describe("messageDataFromRequest", () => {
           trustedBiddingSignalsUrl: "https://trusted-server.example/bidding",
           ads: [
             { renderUrl: "https://ad.example/1", metadata: [undefined] },
-            { renderUrl: "https://ad.example/2", metadata: [Symbol.species] },
+            { renderUrl: "https://ad.example/2", metadata: [Symbol.iterator] },
             { renderUrl: "https://ad.example/3", metadata: [() => null] },
             { renderUrl: "https://ad.example/4", metadata: /abc/ },
             { renderUrl: "https://ad.example/5", metadata: new (class {})() },


### PR DESCRIPTION
The former doesn't seem to be recognized by some TypeScript configurations.