### PR TITLE
Add newline to strings that are supposed to be invalid URLs in tests

### DIFF
--- a/frame/auction_test.ts
+++ b/frame/auction_test.ts
@@ -1257,7 +1257,7 @@ describe("runAdAuction", () => {
       });
     setFakeServerHandler(fakeServerHandler);
     const consoleSpy = spyOnAllFunctions(console);
-    const notUrl = "This string is not a URL.";
+    const notUrl = "This string is not a URL.\n";
     expect(
       await runAdAuction(
         { decisionLogicUrl, trustedScoringSignalsUrl: notUrl },

--- a/lib/public_api_test.ts
+++ b/lib/public_api_test.ts
@@ -602,9 +602,9 @@ describe("FledgeShim", () => {
       expectAsync(
         create().runAdAuction({
           decisionLogicUrl,
-          trustedScoringSignalsUrl: "This string is not a URL.",
+          trustedScoringSignalsUrl: "This string is not a URL.\n",
         })
-      ).toBeRejectedWithError(/.*This string is not a URL\..*/));
+      ).toBeRejectedWithError(/.*This string is not a URL\.\n.*/));
 
     it("should reject on a non-HTTPS URL", () =>
       expectAsync(


### PR DESCRIPTION
Turns out they were actually valid relative URLs and I just didn't realize because the HTTPS check was failing relative to localhost.