### PR TITLE
Use @ sign to make URLs invalid

### DIFF
--- a/frame/auction_test.ts
+++ b/frame/auction_test.ts
@@ -1257,7 +1257,7 @@ describe("runAdAuction", () => {
       });
     setFakeServerHandler(fakeServerHandler);
     const consoleSpy = spyOnAllFunctions(console);
-    const notUrl = "This string is not a URL.\n";
+    const notUrl = "https://invalid@";
     expect(
       await runAdAuction(
         { decisionLogicUrl, trustedScoringSignalsUrl: notUrl },

--- a/lib/public_api_test.ts
+++ b/lib/public_api_test.ts
@@ -602,9 +602,9 @@ describe("FledgeShim", () => {
       expectAsync(
         create().runAdAuction({
           decisionLogicUrl,
-          trustedScoringSignalsUrl: "This string is not a URL.\n",
+          trustedScoringSignalsUrl: "https://invalid@",
         })
-      ).toBeRejectedWithError(/.*This string is not a URL\.\n.*/));
+      ).toBeRejectedWithError(/.*https:\/\/invalid@.*/));
 
     it("should reject on a non-HTTPS URL", () =>
       expectAsync(


### PR DESCRIPTION
The previous change (#242) didn't actually work. This time I tested it in an HTTPS environment.